### PR TITLE
Update keepalive_timeout to 60

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ http {
   gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
 
   tcp_nopush on;
-  keepalive_timeout 30;
+  keepalive_timeout 60;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
   server_tokens off;
 


### PR DESCRIPTION
Addresses https://github.com/fecgov/fec-proxy/issues

Per our engineering sync on 2/16, this PR changes the `nginx` timeout to 60 seconds to match CMS timeout.
