### PR TITLE
making the timeouts longer for the bulk s3 files

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -56,9 +56,10 @@ http {
       proxy_pass_request_headers off;
       proxy_pass <%= ENV["S3_BUCKET_URL"] %>/$1;
     }
-	
+
     location ~ /files/(.*) {
       resolver 8.8.8.8;
+      keepalive_timeout 180;
       proxy_pass_request_headers off;
       proxy_pass <%= ENV["S3_LEGAL_AND_DOWNLOADS_URL"] %>/$1;
     }


### PR DESCRIPTION
I would assume bulk data will take longer since those are the largest, I just tried this with https://fec-dev-proxy.app.cloud.gov/files/bulk-downloads/2016/indiv16.zip and it worked