### PR TITLE
Improve deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,30 @@
 
 Reverse proxy app to combine multiple applications and redirect rules to create a smooth transition for when beta.fec.gov becomes fec.gov.
 
-## Configure
+## Configuration
 
 Set the `PROXIES` environment variable to a JSON object mapping proxy routes to URLs:
 
     cf set-env fec-proxy PROXIES='{"/": "https://app1.18f.gov", "/app2": "https://app1.18f.gov"}'
 
-## Deploy
+## Deployment
 
-Install autopilot:
+Unlike the other applications, the **`master`** branch is usually deployed to all three environments, and there is no special workflow for any updates or hotfixes.
 
-    go get github.com/concourse/autopilot
-    cf install-plugin $GOPATH/bin/autopilot
+Before you start, make sure you have the [`autopilot` (installation instructions)](https://github.com/contraband/autopilot#installation) Cloud Foundry plugin installed.  You can check to see if you have the plugin installed by running `cf plugins` checking if `autopilot` is in the list.
 
-Deploy to desired space:
+Once the plugin is installed, when you're ready to deploy any changes make sure you are on the `master` branch and have done a `git pull` so that all changes are pulled down.  Now run the following commands, where `<space>` is the desired space you'd like to deploy to (`dev`, `stage`, or `prod`):
 
-    cf target -s space
-    cf zero-downtime-push proxy -f manifest_space.yml
+```sh
+    cf target -s <space>
+    cf zero-downtime-push proxy -f manifest_<space>.yml
+```
+
+When the deployment is done, be sure to test the site to make sure everything is still functioning.
+
+### Testing changes before deploying to Production
+
+If you'd like to test any changes before they are fully merged and made a part of the code, you should feel free to do so but only in the `dev` and `staging` spaces.  To do this, just make sure you are on the branch you are currently working in and follow the deployment instructions above.
+
+Just be sure to deploy the `master` branch again once the code is merged in (or the changes are rejected/abandoned).
+


### PR DESCRIPTION
The deployment instructions were a little light and confusing for folks who are used the full `git flow` and CircleCI process we have setup with the API and CMS.  This changeset adds improved instructions on how the deployment process works for the proxy app and includes a note about testing changes before they are merged for deployment to production.