### PR TITLE
Redirect bulk downloads bucket

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -31,6 +31,9 @@ http {
 	client_max_body_size 100M; #increase upload size limit
 	include <%= ENV["APP_ROOT"] %>/public/redirects-www.conf;
 
+  # Redirect for bulk-downloads bucket (needed this redirect here in order to access environment variable)
+  rewrite ^/files/bulk-downloads/(.*)$ <%= ENV["S3_LEGAL_AND_DOWNLOADS_URL"] %>/bulk-downloads/$1 redirect;
+
     <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
     auth_basic "Restricted";
     auth_basic_user_file <%= auth_file %>;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -233,6 +233,3 @@ rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})09([0-9]{2}).*" https://www.
 rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})10([0-9]{2}).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
 rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})11([0-9]{2}).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
 rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})12([0-9]{2}).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;
-
-# Redirect for bulk-downloads bucket
-rewrite ^/files/bulk-downloads/* $S3_BUCKET_URL/files/bulk-downloads/$1 redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -233,3 +233,6 @@ rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})09([0-9]{2}).*" https://www.
 rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})10([0-9]{2}).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
 rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})11([0-9]{2}).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
 rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})12([0-9]{2}).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;
+
+# Redirect for bulk-downloads bucket
+rewrite ^/files/bulk-downloads/* $S3_BUCKET_URL/files/bulk-downloads/$1 redirect;


### PR DESCRIPTION
Addresses https://github.com/fecgov/fec-proxy/issues/75

This will redirect anyone hitting https://www.fec.gov/files/bulk-downloads/ so that they hit the bucket directly instead of going through the proxy. This will allow the user to download large data sets without failure.