### PR TITLE
Added toolkit redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,6 @@
 #Redirect rules for specific pages
 
+rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
 rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;
 rewrite ^/pdf/nongui.pdf https://www.fec.gov/resources/cms-content/documents/nongui.pdf redirect;


### PR DESCRIPTION
This redirects the toolkit page from transition to the new website.

Toolkit page is out of date and we are no longer using toolkits. H4CC includes latest info and forms