### PR TITLE
Improve README around configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Set the `PROXIES` environment variable to a JSON object mapping proxy routes to 
 
 ## Deployment
 
-Unlike the other applications, the **`master`** branch is usually deployed to all three environments, and there is no special workflow for any updates or hotfixes.
+Unlike the other applications, the **`master`** branch is usually deployed to all three environments, and there is no special workflow for any updates or hotfixes. However, it is best to deploy the proxy app at night because it may temporarily effect our routes and wagtail work during deploy.
 
 Before you start, make sure you have the [`autopilot` (installation instructions)](https://github.com/contraband/autopilot#installation) Cloud Foundry plugin installed.  You can check to see if you have the plugin installed by running `cf plugins` checking if `autopilot` is in the list.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reverse proxy app to combine multiple applications and redirect rules to create 
 
 Set the `PROXIES` environment variable to a JSON object mapping proxy routes to URLs. As an example, you can do this manually with a command similar to this:
 
-    cf set-env fec-proxy PROXIES='{"/": "https://app1.18f.gov", "/app2": "https://app1.18f.gov"}'
+    cf set-env fec-proxy PROXIES='{"/": "https://app1.app.cloud.gov", "/app2": "https://app1.app.cloud.gov"}'
 
 *Note that this is currently set and configured in the manifest files for deployment.*
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Reverse proxy app to combine multiple applications and redirect rules to create 
 
 ## Configuration
 
-Set the `PROXIES` environment variable to a JSON object mapping proxy routes to URLs:
+Set the `PROXIES` environment variable to a JSON object mapping proxy routes to URLs. As an example, you can do this manually with a command similar to this:
 
     cf set-env fec-proxy PROXIES='{"/": "https://app1.18f.gov", "/app2": "https://app1.18f.gov"}'
+
+*Note that this is currently set and configured in the manifest files for deployment.*
 
 ## Deployment
 


### PR DESCRIPTION
This changeset adds a bit of clarity to the README instructions around the proxy configuration.  It explicitly calls out the command given as an example for manual configuration and includes a note that the configuation is normaly set and configured in the manifest files for deployment.