### PR TITLE
Update redirects-transition.conf for misspelled URL

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,6 @@
 #Redirect rules for specific pages
 
+rewrite ^/info/ElectionDate/2018/PA__07.shtml https://transition.fec.gov/info/ElectionDate/2018/PA_07.shtml redirect;
 rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
 rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;


### PR DESCRIPTION
Two compliance pages were put up for the PA/07 election. The first one has a misspelled URL (using two underscores intead of one) so we are redirecting that one to the correctly spelled URL.

Basically redirecting https://transition.fec.gov/info/ElectionDate/2018/PA__07.shtml to point to https://transition.fec.gov/info/ElectionDate/2018/PA_07.shtml