### PR TITLE
Update redirects for info brochures and forms

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,21 @@
 #Redirect rules for specific pages
 
+rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
+rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
+rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;
+rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/ redirect;
+rewrite ^/pages/brochures/ao_brochure.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
+rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
+rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/checkoff.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#primary-matching-funds
+rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
+rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
 rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
 rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;
@@ -39,7 +55,7 @@ rewrite ^/info/report_dates.shtml https://www.fec.gov/help-candidates-and-commit
 rewrite ^/pages/contact.shtml https://www.fec.gov/contact-us/ redirect;
 rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
 rewrite ^/pages/brochures/bestpractices.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
-rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/coordinated-communications/ redirect;
+rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-independent-expenditures-ssf-corporation-labor-organization/ redirect;
 rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/updates/national-party-convention-delegates-2/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,8 +1,8 @@
 #Redirect rules for specific pages
 
-rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
-rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
-rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs/ redirect;
+rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs/ redirect;
+rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs redirect;
 rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
 rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
 rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;


### PR DESCRIPTION
This updates the URLS for outdated brochures, pages and forms on transition, including:

Audio forms
AO brochure
Filing a Complaint brochure
Public funding brochure
Lobbying FAQ
Nonfederal fundraising FAQ
Corporate Guide
