### PR TITLE
Redirect links for tips pages and FECFile manuals on transition

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,10 @@
 #Redirect rules for specific pages
 
+rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf redirect;
+rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
+rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf redirect;
+rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
 rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;
@@ -87,6 +92,7 @@ rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/adviso
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
 
 #This section is for broader redirects
+rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treasurers$1 redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
 rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;


### PR DESCRIPTION
This pull request creates redirects for the three FECfile manuals and the old yearly tips archive pages.