### PR TITLE
Update redirects-transition.conf to redirect two quick answers pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,7 @@
 #Redirect rules for specific pages
 
+rewrite ^/ans/answers_candidate.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
+rewrite ^/ans/answers_filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/info/outreach.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
 rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
 rewrite ^/elecfil/electron.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;


### PR DESCRIPTION
Putting in two redirects for quick answers pages that merely duplicate existing content on the main website.