### PR TITLE
Adds redirects for IG page and documents

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -123,8 +123,11 @@ rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resour
 rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
+rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
 
 #This section is for broader redirects
+rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
+rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
 rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treasurers$1 redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -144,8 +144,9 @@ rewrite ^/audio/images/audio.png https://transition.fec.gov/images/audio.png red
 rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcript_icon.png redirect;
 rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
 rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
+rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
 
-#This section is for broader redirects
+# This section is for broader redirects
 rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;
 rewrite ^/fecviewer/CommitteeDetailFilings.do /data/?search=$arg_candidateCommitteeId redirect;
 rewrite ^/pdf/nprm/(.*) /resources/legal-resources/rulemakings/nprm/$1 redirect;
@@ -154,7 +155,8 @@ rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
 rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
 rewrite ^/pdf/record/(.*).pdf /resources/record/$1.pdf redirect;
 rewrite ^/law/litigation/(.*) https://transition.fec.gov/law/litigation/$1 redirect;
-rewrite ^/fecig/(.*) https://transition.fec.gov/fecig/$1 redirect;
+rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
+rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
 rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;
 rewrite ^/info/conferences/(.*) http://transition.fec.gov/info/conferences/$1 redirect;
 rewrite ^/info/conference_materials/(.*) http://transition.fec.gov/info/conference_materials/$1 redirect;


### PR DESCRIPTION
This will redirect old inspector general pages on transition to the new Wagtail page located here: https://www.fec.gov/office-inspector-general/. In addition any PDF documents that were stored under the /fecig/ directory on transition will be redirected to the wagtail documents bucket.