### PR TITLE
Catch up on content www redirects - cms issue 2350

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -144,18 +144,18 @@ rewrite ^/audio/images/audio.png https://transition.fec.gov/images/audio.png red
 rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcript_icon.png redirect;
 rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
 rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
-rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
-rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf;
-rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers;
-rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers;
-rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/;
-rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/;
-rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/;
-rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/;
-rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/;
-rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/;
-rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/;
-rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/;
+rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/; redirect;
+rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf; redirect;
+rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers; redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers; redirect;
+rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/; redirect;
+rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/; redirect;
+rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/; redirect;
+rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/; redirect;
+rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/; redirect;
+rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/; redirect;
+rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/; redirect;
+rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/; redirect;
 
 # This section is for broader redirects
 rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -144,18 +144,18 @@ rewrite ^/audio/images/audio.png https://transition.fec.gov/images/audio.png red
 rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcript_icon.png redirect;
 rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
 rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
-rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/; redirect;
-rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf; redirect;
-rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers; redirect;
-rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers; redirect;
-rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/; redirect;
-rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/; redirect;
-rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/; redirect;
-rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/; redirect;
-rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/; redirect;
-rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/; redirect;
-rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/; redirect;
-rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/; redirect;
+rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
+rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
+rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
+rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;
+rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/ redirect;
+rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
+rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 
 # This section is for broader redirects
 rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -145,6 +145,17 @@ rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcrip
 rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
 rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
 rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
+rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf;
+rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers;
+rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers;
+rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/;
+rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/;
+rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/;
+rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/;
+rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/;
+rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/;
+rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/;
+rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/;
 
 # This section is for broader redirects
 rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;


### PR DESCRIPTION
This is for catching up on www redirects from old transition pages to their replacement pages in the CMS. The proxy redirects had already been done. 

This spreadsheet contains what we are redirecting in this PR:
https://docs.google.com/spreadsheets/d/1E8wnT98QYqWE3x3UK28mlgrxyDd3cghYFOuD2aKmxSQ/edit?usp=sharing

Resolves https://github.com/fecgov/fec-cms/issues/2350