### PR TITLE
Update transition redirects for quick answers

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,16 @@
 #Redirect rules for specific pages
 
+rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
+rewrite ^/ans/answers_compliance.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/ans/answers_pac.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_party.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/info/election_day_links.shtml https://www.fec.gov/introduction-campaign-finance/election-day-information/ redirect;
+rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
+rewrite ^/law/litigation/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/info/articles/debtretirement09.pdf https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
+rewrite ^/info/articles/windingdown09.pdf https://www.fec.gov/help-candidates-and-committees/winding-down-candidate-campaign/ redirect;
+rewrite ^/info/guidance/hlogabundling.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/ redirect;
 rewrite ^/ans/answers_candidate.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
 rewrite ^/ans/answers_filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/info/outreach.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
@@ -81,7 +92,6 @@ rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-c
 rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/updates/national-party-convention-delegates-2/ redirect;
-rewrite ^/ans/answers_compliance.shtml#embezzlement1 https://www.fec.gov/help-candidates-and-committees/keeping-records/misappropriated-funds/ redirect;
 rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
 rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;


### PR DESCRIPTION
Redirects various quick answers and related pages on the transition site to their new homes on the main site. (See connected issue for list of pages being redirected/new pages.)