### PR TITLE
Adds redirects for two legislative recommendations

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,7 @@
 #Redirect rules for specific pages
 
+rewrite ^/info/LegislativeRecommendations1993.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect;
+rewrite ^/pages/legislative_recommendations_2004.htm https://www.fec.gov/resources/cms-content/documents/legrec2004.pdf redirect;
 rewrite ^/info/hearings.shtml https://www.fec.gov/meetings/?tab=hearings redirect;
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
 rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;


### PR DESCRIPTION
Broader redirects didn't work for 2004 and 1993 so this is a fix for that.

