### PR TITLE
[Merge AFTER 7.7 release] Add redirect from /advanced to /browse-data

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -148,6 +148,7 @@ rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committ
 rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 
 # This section is for broader redirects
+rewrite ^/data/advanced/$ /data/browse-data/ redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;


### PR DESCRIPTION
Merge after CMS PR: https://github.com/fecgov/fec-cms/pull/2581

This redirects the /advanced url to /browse-data

Related issue https://github.com/fecgov/fec-cms/issues/2306