### PR TITLE
Adding redirects for agenda pages to transition

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -168,3 +168,17 @@ rewrite ^/sunshine/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/sunsh
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/MUR/.* http://classic.fec.gov/MUR/ redirect;
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
+
+# Captures all dates of format agenda/YYYY/agendaYYYYMMDD
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})01([0-9]{2}).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})02([0-9]{2}).*" https://www.fec.gov/updates/february-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})03([0-9]{2}).*" https://www.fec.gov/updates/march-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})04([0-9]{2}).*" https://www.fec.gov/updates/april-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})05([0-9]{2}).*" https://www.fec.gov/updates/may-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})06([0-9]{2}).*" https://www.fec.gov/updates/june-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})07([0-9]{2}).*" https://www.fec.gov/updates/july-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})08([0-9]{2}).*" https://www.fec.gov/updates/august-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})09([0-9]{2}).*" https://www.fec.gov/updates/september-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})10([0-9]{2}).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})11([0-9]{2}).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})12([0-9]{2}).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;


### PR DESCRIPTION
Resolves #https://github.com/fecgov/fec-cms/issues/2593

The transition agenda pages 404s, this PR adds the agenda page redirects to transition.