### PR TITLE
Update transition redirects to new other filers pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,6 @@
 #Redirect rules for specific pages
 
+rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/info/LegislativeRecommendations1993.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect;
 rewrite ^/pages/legislative_recommendations_2004.htm https://www.fec.gov/resources/cms-content/documents/legrec2004.pdf redirect;
 rewrite ^/info/hearings.shtml https://www.fec.gov/meetings/?tab=hearings redirect;
@@ -40,7 +41,7 @@ rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidat
 rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;
 rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2018/ redirect;
 rewrite ^/pages/brochures/ao_brochure.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
-rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
 rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
@@ -93,14 +94,14 @@ rewrite ^/info/report_dates.shtml https://www.fec.gov/help-candidates-and-commit
 rewrite ^/pages/contact.shtml https://www.fec.gov/contact-us/ redirect;
 rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
 rewrite ^/pages/brochures/bestpractices.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
-rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-independent-expenditures-ssf-corporation-labor-organization/ redirect;
+rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/updates/national-party-convention-delegates-2/ redirect;
 rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
 rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
-rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
 rewrite ^/pages/brochures/TestingtheWaters.shtml https://www.fec.gov/updates/testing-the-waters-2017/ redirect;
 rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;


### PR DESCRIPTION
Redirecting some outdated transition pages to new other filers pages and updating some existing redirects to point to the new pages.

Here are old and new URLs for testing:
![image](https://user-images.githubusercontent.com/24437369/52301631-dc378e00-2958-11e9-8bd3-9e40bb61146d.png)
