### PR TITLE
Update redirects for forms and AF

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,11 +1,13 @@
 #Redirect rules for specific pages
 
+rewrite ^/af/af_calc.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
 rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/info/LegislativeRecommendations1993.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect;
 rewrite ^/pages/legislative_recommendations_2004.htm https://www.fec.gov/resources/cms-content/documents/legrec2004.pdf redirect;
 rewrite ^/info/hearings.shtml https://www.fec.gov/meetings/?tab=hearings redirect;
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
 rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
+rewrite ^/ans/answers.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
 rewrite ^/ans/answers_compliance.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
@@ -33,9 +35,6 @@ rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introd
 rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pdf/eleccoll.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
 rewrite ^/law/feca/feca.pdf https://www.fec.gov/resources/cms-content/documents/feca.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs/ redirect;
-rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs/ redirect;
-rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/help-candidates-and-committees/forms/#political-parties-and-political-action-committees-pacs redirect;
 rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
 rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
 rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;
@@ -152,6 +151,7 @@ rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/lega
 rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
 
 #This section is for broader redirects
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/help-candidates-and-committees/forms/$1 redirect;
 rewrite ^/info/legrec.htm https://www.fec.gov/resources/cms-content/documents/legrec1997.pdf;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;


### PR DESCRIPTION
Deleted three specific form redirects for a broader redirect for the whole directory of forms, added redirect for AF calculator , and a quick answer page.

@patphongs for the broader redirects some did not have "redirect;" at the end, but most did, so we did that for our redirect we added "redirect;" . Just wanted to bring this to your attention. 