### PR TITLE
Update www redirects for quick answers and forms

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -1,5 +1,14 @@
 #Redirect rules for specific pages
 
+rewrite ^/ans/answers.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
+rewrite ^/ans/answers_compliance.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/ans/answers_pac.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_party.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_candidate.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
+rewrite ^/ans/answers_filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/info/guidance/hlogabundling.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2019/ redirect;
 rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
@@ -40,7 +49,7 @@ rewrite ^/em/respondent_guide.pdf https://transition.fec.gov/em/respondent_guide
 rewrite ^/af/af.shtml https://transition.fec.gov/af/af.shtml redirect;
 rewrite ^/pages/brochures/admin_fines.shtml /legal-resources/enforcement/administrative-fines/ redirect;
 rewrite ^/af/AFPRegulations.shtml https://transition.fec.gov/af/AFPRegulations.shtml redirect;
-rewrite ^/af/af_calc.shtml https://transition.fec.gov/af/af_calc.shtml redirect;
+rewrite ^/af/af_calc.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
 rewrite ^/em/adr.shtml /legal-resources/enforcement/alternative-dispute-resolution/ redirect;
 rewrite ^/audits/audit_reports.shtml https://transition.fec.gov/audits/audit_reports.shtml redirect;
 rewrite ^/audits/audit_reports_auth.shtml https://transition.fec.gov/audits/audit_reports_auth.shtml redirect;
@@ -182,7 +191,7 @@ rewrite ^/disclosure/(.*) http://classic.fec.gov/disclosure/$1 redirect;
 rewrite ^/disclosureie/(.*) http://classic.fec.gov/disclosureie/$1 redirect;
 rewrite ^/MUR/(.*) http://classic.fec.gov/MUR/ redirect;
 rewrite ^/auditsearch/(.*) http://classic.fec.gov/auditsearch/$1 redirect;
-rewrite ^/pdf/forms/(.*) https://transition.fec.gov/pdf/forms/$1 redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/help-candidates-and-committees/forms/$1 redirect;
 rewrite ^/law/cfr/ej_compilation/(.*) https://transition.fec.gov/law/cfr/ej_compilation/$1 redirect;
 rewrite ^/sunshine/([0-9]+)/(.*).pdf /resources/updates/sunshine-notices/$1/$2.pdf redirect;
 rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;


### PR DESCRIPTION
Updates were made to add redirects for all quick answers and to update redirects for the AF calculator and forms directory to the current pages.  See issue #2600. 