### PR TITLE
Increase timeout settings

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,9 @@ http {
   gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
 
   tcp_nopush on;
-  keepalive_timeout 60;
+  keepalive_timeout 300;
+  proxy_connect_timeout 300;
+  proxy_read_timeout 300;
   port_in_redirect off; # Ensure that redirects don't include the internal container PORT - <%= ENV["PORT"] %>
   server_tokens off;
 


### PR DESCRIPTION
Increase timeout settings on the proxy in order to allow the API to retrieve longer queries.