### PR TITLE
Added cflinuxfs3 to the stack specifications

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,4 +1,5 @@
 ---
+stack: cflinuxfs3
 buildpack: staticfile_buildpack
 applications:
   - name: proxy

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,4 +1,5 @@
 ---
+stack: cflinuxfs3
 buildpack: staticfile_buildpack
 applications:
   - name: proxy

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -1,4 +1,5 @@
 ---
+stack: cflinuxfs3
 buildpack: staticfile_buildpack
 applications:
   - name: proxy


### PR DESCRIPTION
Resolves #119 

Specifying `cflinuxfs3` stack to make sure that we are upgraded to the latest for testing before the cflinuxfs2 is deprecated in April.

I have tested pushing v3 in dev and stage with no issues.