### PR TITLE
updated forms redirect to correct url

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -151,7 +151,7 @@ rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/lega
 rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
 
 #This section is for broader redirects
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/help-candidates-and-committees/forms/$1 redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 rewrite ^/info/legrec.htm https://www.fec.gov/resources/cms-content/documents/legrec1997.pdf;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -191,7 +191,7 @@ rewrite ^/disclosure/(.*) http://classic.fec.gov/disclosure/$1 redirect;
 rewrite ^/disclosureie/(.*) http://classic.fec.gov/disclosureie/$1 redirect;
 rewrite ^/MUR/(.*) http://classic.fec.gov/MUR/ redirect;
 rewrite ^/auditsearch/(.*) http://classic.fec.gov/auditsearch/$1 redirect;
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/help-candidates-and-committees/forms/$1 redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 rewrite ^/law/cfr/ej_compilation/(.*) https://transition.fec.gov/law/cfr/ej_compilation/$1 redirect;
 rewrite ^/sunshine/([0-9]+)/(.*).pdf /resources/updates/sunshine-notices/$1/$2.pdf redirect;
 rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;


### PR DESCRIPTION
This fixes forms redirect go to Wagtail documents bucket instead: `/resources/cms-content/documents/`