### PR TITLE
Update www redirects 8.3 for inflation notices and compliance map

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -1,5 +1,27 @@
 #Redirect rules for specific pages
 
+rewrite ^/info/charts_cpe_2017.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice2017-02.pdf redirect;
+rewrite ^/info/charts_cpe_2016.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
+rewrite ^/info/charts_cpe_2015.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
+rewrite ^/info/charts_441ad_2014.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
+rewrite ^/info/charts_441ad_2013.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
+rewrite ^/info/charts_441ad_2012.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
+rewrite ^/info/charts_441ad_2011.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
+rewrite ^/info/charts_441ad_2010.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
+rewrite ^/info/charts_441ad.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2008/notice_2008-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2008-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
+rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/ans/answers.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
@@ -162,6 +184,7 @@ rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committ
 rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 
 # This section is for broader redirects
+rewrite ^/info/ElectionDate/(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/data/advanced/$ /data/browse-data/ redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;


### PR DESCRIPTION
Redirecting old inflation notices and related pages to FR notices in CMS. Redirected compliance map and sub directories to dates and deadlines page.

@patphongs Please especially double check the broader redirect: we want everything in the "election date" sub directory to go to Dates and deadlines.