### PR TITLE
Update to redirects 8.4

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,9 +1,8 @@
 #Redirect rules for specific pages
 
-rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
-rewrite ^/info/guidance/debt_retirement.shtml https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
+
+
 rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/publications/fecglossary2009.pdf https://www.fec.gov/help-candidates-and-committees/guides/ redirect;
 rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/updates/testing-the-waters-for-possible-candidacy-2019/ redirect;
 rewrite ^/info/charts_cpe_2017.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice2017-02.pdf redirect;
 rewrite ^/info/charts_cpe_2016.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;


### PR DESCRIPTION
The following have been deleted from the initial Proxy redirects and done via Wagtail:

rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
rewrite ^/info/guidance/debt_retirement.shtml https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
rewrite ^/info/publications/fecglossary2009.pdf https://www.fec.gov/help-candidates-and-committees/guides/ redirect;