### PR TITLE
Add stage.fec.gov route

### DIFF
--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -6,6 +6,7 @@ applications:
     memory: 64M
 routes:
   - route: fec-stage-proxy.app.cloud.gov
+  - route: stage.fec.gov
 services:
   - fec-creds-stage
 env:


### PR DESCRIPTION
This adds the stage.fec.gov route after cdn configurations have been completed.