### PR TITLE
9.1 Redirect Work in transition

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,14 @@
 #Redirect rules for specific pages
 
+rewrite ^/info/publications.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect;
+rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
+rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/contrib.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect; 
+rewrite ^/pages/brochures/contributions_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
+rewrite ^/pages/brochures/contributions_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
+rewrite ^/pages/brochures/volact.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/volunteer_activity_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/volunteer_activity_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;


### PR DESCRIPTION
Updated some more publications and brochure links to remove them from transition to fec.gov