### PR TITLE
Update transition redirects for 9.4

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -104,7 +104,7 @@ rewrite ^/pages/brochures/checkoff.shtml https://www.fec.gov/introduction-campai
 rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
 rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
-rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/documents/189/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
+rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
 rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
 rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -104,7 +104,7 @@ rewrite ^/pages/brochures/checkoff.shtml https://www.fec.gov/introduction-campai
 rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
 rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
-rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf redirect;
+rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/documents/189/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
 rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
 rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,8 @@
 #Redirect rules for specific pages
 
+rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/advertising/ redirect;
+rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
+rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
 rewrite ^/info/publications.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect;
 rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
@@ -103,7 +106,7 @@ rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resou
 rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
 rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf redirect;
 rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
-rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf redirect;
+rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/ElectionDate/2018/PA__07.shtml https://transition.fec.gov/info/ElectionDate/2018/PA_07.shtml redirect;


### PR DESCRIPTION
Updating one redirect for old FECFile manual and adding three new ones for publications moving off transition.

How to test:
Here is a screenshot of the pages, the old URLs and the new URLs. Redirects for the special notices brochure and the  Guideline for Presentation in Good Order. An older FECFile manual was redirecting to the 2017 version, but that version was just replaced, so the redirect was updated to point to the new URL.

![image](https://user-images.githubusercontent.com/24437369/60354814-1e5e7c00-999b-11e9-85de-a8eb5fa05522.png)
