### PR TITLE
Adds redirect for the 2002 meeting minutes

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -242,10 +242,10 @@ rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treas
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
 rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;
-rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1 redirect;
-rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1 redirect;
-rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1 redirect;
-rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1 redirect;
+rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1.pdf redirect;
+rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1.pdf redirect;
+rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
+rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
 rewrite ^/audio/([0-9]+)/(.*) https://www.fec.gov/resources/audio/$1/$2 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -242,6 +242,7 @@ rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treas
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
 rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;
+rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1 redirect;
 rewrite ^/audio/([0-9]+)/(.*) https://www.fec.gov/resources/audio/$1/$2 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -242,7 +242,10 @@ rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treas
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
 rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;
-rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1 redirect;
+rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1 redirect;
+rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1 redirect;
+rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1 redirect;
+rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1 redirect;
 rewrite ^/audio/([0-9]+)/(.*) https://www.fec.gov/resources/audio/$1/$2 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;


### PR DESCRIPTION
The 2002 meeting minutes were in a subdirectory with a different name path than other years, so are 404'ing.

Old path: /agenda/agendas2002/*.pdf

I've put in a broader redirect for that subdirectory. 

If this works, it resolves #3266 