### PR TITLE
Update redirects for presidential matching funds (transition)

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -223,8 +223,12 @@ rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resour
 rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
-rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/;
-
+rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
+rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml redirect;
+rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml redirect;
+rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/finance/2012matching/2012matching.shtml redirect;
+rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
+rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
 #This section is for broader redirects
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/info/articles/(.*) https://www.fec.gov/updates/ redirect; 
@@ -255,7 +259,6 @@ rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agen
 rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
 rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
 rewrite ^/audio/([0-9]+)/(.*) https://www.fec.gov/resources/audio/$1/$2 redirect;
-rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;
 rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
 rewrite ^/portal/(.*) http://classic.fec.gov/portal/$1 redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -208,6 +208,11 @@ rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-comm
 rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
+rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml redirect;
+rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml redirect;
+rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/finance/2012matching/2012matching.shtml redirect;
+rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
+rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
 
 # This section is for broader redirects
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;


### PR DESCRIPTION
Points them to their transition pages.

Redirects to these pages

https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml
https://transition.fec.gov/finance/2012matching/2012matching.shtml
https://transition.fec.gov/finance/2008matching/2008matching.shtml
https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml