### PR TITLE
Removed transition matching fund redirects that caused conflict

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -224,10 +224,6 @@ rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-
 rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
 rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
-rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml redirect;
-rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml redirect;
-rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/finance/2012matching/2012matching.shtml redirect;
-rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
 rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
 #This section is for broader redirects
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
@@ -264,12 +260,10 @@ rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
 rewrite ^/portal/(.*) http://classic.fec.gov/portal/$1 redirect;
 rewrite ^/disclosurep/(.*) http://classic.fec.gov/disclosurep/$1 redirect;
 rewrite ^/disclosurehs/(.*) http://classic.fec.gov/disclosurehs/$1 redirect;
-rewrite ^/disclosure/(.*) http://classic.fec.gov/disclosure/$1 redirect;
 rewrite ^/disclosureie/(.*) http://classic.fec.gov/disclosureie/$1 redirect;
 rewrite ^/data/(.*) http://classic.fec.gov/data/$1 redirect;
 rewrite ^/auditsearch/(.*) http://classic.fec.gov/auditsearch/$1 redirect;
 rewrite ^/sunshine/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/sunshine-notices/$1/$2.pdf redirect;
-rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/MUR/.* http://classic.fec.gov/MUR/ redirect;
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 


### PR DESCRIPTION
Removed transition domain's matching fund redirects and generic /finance/* and /finance/disclosure/* redirects as they were conflicting with www redirects