### PR TITLE
Redirect old transition open government page to new wagtail page

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -23,6 +23,7 @@ rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
 rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
+rewrite ^/open/index.shtml /open/ redirect;
 rewrite ^/info/publications.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect;
 rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
 rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -150,7 +150,7 @@ rewrite ^/pages/jobs/jobs.shtml /about/careers/ redirect;
 rewrite ^/eeo/eeo.shtml https://transition.fec.gov/eeo/eeo.shtml redirect;
 rewrite ^/working.shtml /about/#working-with-the-fec redirect;
 rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
-rewrite ^/open/index.shtml https://transition.fec.gov/open/index.shtml redirect;
+rewrite ^/open/index.shtml /open/ redirect;
 rewrite ^/press/index.shtml /press/ redirect;
 rewrite ^/press/news_releases.shtml /updates/?update_type=press-release redirect;
 rewrite ^/press/weekly_digests.shtml /updates/?update_type=weekly-digest redirect;


### PR DESCRIPTION
This PR redirects the old transition open government page to the new wagtail page.