### PR TITLE
Adding domain to open government URL for transition redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -23,7 +23,7 @@ rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
 rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
-rewrite ^/open/index.shtml /open/ redirect;
+rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
 rewrite ^/info/publications.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect;
 rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
 rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;


### PR DESCRIPTION
I forgot to add the domain to the transition redirect for the open government page. This PR adds this and corrects this error. This fix has already been deployed but needs to be backfilled into master.