### PR TITLE
Update guidance doc www redirects

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -1,5 +1,6 @@
 #Redirect rules for specific pages
 
+
 rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
 rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
 rewrite ^/rad/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
@@ -38,6 +39,17 @@ rewrite ^/info/charts_441ad_2012.shtml https://www.fec.gov/resources/cms-content
 rewrite ^/info/charts_441ad_2011.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
 rewrite ^/info/charts_441ad_2010.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
 rewrite ^/info/charts_441ad.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
@@ -96,7 +108,7 @@ rewrite ^/calendar/calendar.shtml http://classic.fec.gov/calendar/calendar.shtml
 rewrite ^/law/legalconsideration.shtml https://transition.fec.gov/law/legalconsideration.shtml redirect;
 rewrite ^/em/em.shtml /legal-resources/enforcement/ redirect;
 rewrite ^/em/enfpro/EnforcementProfile.shtml https://transition.fec.gov/em/enfpro/EnforcementProfile.shtml redirect;
-rewrite ^/em/respondent_guide.pdf https://transition.fec.gov/em/respondent_guide.pdf redirect;
+rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/documents/respondent_guide.pdf redirect;
 rewrite ^/af/af.shtml https://transition.fec.gov/af/af.shtml redirect;
 rewrite ^/pages/brochures/admin_fines.shtml /legal-resources/enforcement/administrative-fines/ redirect;
 rewrite ^/af/AFPRegulations.shtml https://transition.fec.gov/af/AFPRegulations.shtml redirect;
@@ -166,8 +178,8 @@ rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and
 rewrite ^/pages/procure/procure.shtml /about/reports-about-fec/procurement-and-contracting/ redirect;
 rewrite ^/pages/anreport.shtml /about/reports-about-fec/annual-and-anniversary-reports/ redirect;
 rewrite ^/privacy.shtml /about/privacy-and-security-policy redirect;
-rewrite ^/info/FECWebinars.shtml https://transition.fec.gov/info/FECWebinars.shtml redirect;
-rewrite ^/info/roundtable_materials/workshopmaterials.shtml https://transition.fec.gov/info/roundtable_materials/workshopmaterials.shtml redirect;
+rewrite ^/info/FECWebinars.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/roundtable_materials/workshopmaterials.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
 rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
 rewrite ^/press/foia.shtml /freedom-information-act/ redirect;
 rewrite ^/press/bkgnd/presidential_fund.shtml https://transition.fec.gov/press/bkgnd/presidential_fund.shtml redirect;


### PR DESCRIPTION
Contains the www redirects for guidance docs that were in E&J directory.

Also some updated:  A guidance doc file /em/respondent_guide.pdf already was in www redirect so I updated that one. Plus I noticed two older webinar addresses needed updating so I took care of those too and redirected to trainings page.