### PR TITLE
Updates transition redirects for 12.3 part 2 of 2

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,19 @@
 #Redirect rules for specific pages
 
+rewrite ^/pdf/2017-2018_rad_review_referral_procedures.pdf https://www.fec.gov/resources/cms-content/documents/2017-2018_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures_2015-16.pdf https://www.fec.gov/resources/cms-content/documents/2015-2016_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures_2013-14.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/2016title26materialitythresholdsapproved09132016_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2016_audit_materiality_thresholds_title_26_presidential.pdf redirect;
+rewrite ^/pdf/2014AuthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_authorized.pdf redirect;
+rewrite ^/pdf/2014UnauthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_unauthorized.pdf redirect;
+rewrite ^/pdf/2012title2authmaterialitythresholdsapprvd72313_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_authorized.pdf redirect;
+rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
+rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
+rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
+rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
+rewrite ^/pdf/audit_threshold_title26_2008.pdf https://www.fec.gov/resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
+rewrite ^/pages/brochures/audit_process.pdf https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;


### PR DESCRIPTION
@djgarr submitted part 1 in https://github.com/fecgov/fec-proxy/pull/165

Puts transition redirects in for various RAD and Audit enforcement documents.

See our spreadsheet at https://docs.google.com/spreadsheets/d/1Jn5nC3fFku10RTCP5OAW6RiffjNBE4VwBubITQpCNK8/edit?usp=sharing