### PR TITLE
Add redirect for press resource files

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -277,6 +277,7 @@ rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;
 rewrite ^/info/conferences/(.*) http://transition.fec.gov/info/conferences/$1 redirect;
 rewrite ^/info/conference_materials/(.*) http://transition.fec.gov/info/conference_materials/$1 redirect;
 rewrite ^/pages/report_notices/(.*) http://transition.fec.gov/pages/report_notices/$1 redirect;
+rewrite ^/press/press([0-9]+)/(.*) /resources/news_releases/$1/$2 redirect;
 rewrite ^/press/press(.*) http://transition.fec.gov/press/press$1 redirect;
 rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
 rewrite ^/portal/(.*) http://classic.fec.gov/portal/$1 redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -277,7 +277,7 @@ rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;
 rewrite ^/info/conferences/(.*) http://transition.fec.gov/info/conferences/$1 redirect;
 rewrite ^/info/conference_materials/(.*) http://transition.fec.gov/info/conference_materials/$1 redirect;
 rewrite ^/pages/report_notices/(.*) http://transition.fec.gov/pages/report_notices/$1 redirect;
-rewrite ^/press/press([0-9]+)/(.*) /resources/news_releases/$1/$2 redirect;
+rewrite ^/press/press([0-9]+)/(.*) https://www.fec.gov/resources/news_releases/$1/$2 redirect;
 rewrite ^/press/press(.*) http://transition.fec.gov/press/press$1 redirect;
 rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
 rewrite ^/portal/(.*) http://classic.fec.gov/portal/$1 redirect;


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-cms/issues/3451

This redirects /press/press[YEAR]/ to /press/news_releases/[year]/.

## How to test
@dorothyyeager I have deployed these changes to dev so that you can easily test. These were the sample URLs to files that were broken. Now they should redirect correctly to the appropriate path on the content-s3 bucket. 

https://dev.fec.gov/press/press2008/20080226letter.PDF
https://dev.fec.gov/press/press2008/FECtoMcCain.PDF
https://dev.fec.gov/press/press2008/mccainletter.pdf
https://dev.fec.gov/press/press2008/20080220c1image.pdf