### PR TITLE
Updates transition redirects for various projects (admin fines, election results, enforcement page)

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -11,6 +11,7 @@ rewrite ^/af/documents/2016AFPRegulations.pdf https://sers.fec.gov/fosers/showpd
 rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
 rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/elections.html https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
 rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
 rewrite ^/pdf/1997_Enforcement_Manual.pdf https://www.fec.gov/resources/cms-content/documents/1997_enforcement_manual.pdf redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,5 +1,16 @@
 #Redirect rules for specific pages
 
+rewrite ^/af/afcalc_20130725.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_20160701.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_post-200907.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/af.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
+rewrite ^/af/AFPRegulations.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/#legal-citations redirect;
+rewrite ^/af/pay.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/#paying-a-fine redirect;
+rewrite ^/af/payment/index.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/#paying-a-fine redirect;
+rewrite ^/af/documents/2016AFPRegulations.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=351065 redirect;
+rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
+rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
 rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
 rewrite ^/pdf/1997_Enforcement_Manual.pdf https://www.fec.gov/resources/cms-content/documents/1997_enforcement_manual.pdf redirect;
@@ -267,7 +278,27 @@ rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/adviso
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
 rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
 rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
+
 #This section is for broader redirects
+rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2016/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2014/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2012/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2010/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2008/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2006/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2004/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2002/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2000/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1998/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1994/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1992/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1990/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/info/articles/(.*) https://www.fec.gov/updates/ redirect; 
 rewrite ^/info/presentations/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;


### PR DESCRIPTION
Redirects for:
Administrative fines Resolves #3783 and mentioned in #3789
Election results #3827
Enforcement procedural materials page #3827

Question for @pat: Did I do the broader redirect correctly? Each of those directories in transition contains 1 or more documents but no subfolders.