### PR TITLE
WIP PR: Organizing transition redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -91,6 +91,7 @@ rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-comm
 rewrite ^/elecfil/electron.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/elecfil/FECFileIntroPage.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/fecfile-software/ redirect;
 rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/passwords.html https://webforms.fec.gov/psa/getstarted.htm redirect;
 rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 rewrite ^/elecfil/vendors.shtml	https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -398,12 +398,23 @@ rewrite ^press/bkgnd/fund.shtml https://www.fec.gov/introduction-campaign-financ
 rewrite ^/privacy.shtml https://www.fec.gov/about/privacy-and-security-policy/ redirect;
 
 # pubrec/ redirects
+rewrite ^/pubrec/2000pres.htm https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/candidates/ redirect;
+rewrite ^/pubrec/2000presgeresults.htm https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/federal-elections-2000/ redirect;
+rewrite ^/pubrec/2008pdates.pdf https://www.fec.gov/resources/cms-content/documents/2008pdates.pdf redirect;
+rewrite ^/pubrec/access.htm https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
 rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/prguide1.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
+rewrite ^/pubrec/publicrecords.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
+rewrite ^/pubrec/staterec.htm https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
+rewrite ^/pubrec/faxline.pdf https://www.fec.gov/introduction-campaign-finance/ redirect;
+rewrite ^/pubrec/faxmenu.shtml https://www.fec.gov/introduction-campaign-finance/ redirect;
+rewrite ^/pubrec/publicrecordsoffice.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
 
 # pubrec/cfsdd/ redirects
-rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/cfsdd/ https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
+rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
+
 
 # rad/ redirects
 rewrite ^/rad/index.shtml /rad/index.html redirect;
@@ -502,6 +513,7 @@ rewrite ^/pubrec/fe2006/(.*) https://www.fec.gov/introduction-campaign-finance/e
 rewrite ^/pubrec/fe2004/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2002/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2000/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1996/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1998/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1994/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1992/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -510,6 +522,7 @@ rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/e
 rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/pacronyms/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/pacs-parties-and-other-committees/ redirect;
 
 # sunshine/ broader redirects
 rewrite ^/sunshine/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/sunshine-notices/$1/$2.pdf redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1,116 +1,114 @@
 #Redirect rules for specific pages
 
-rewrite ^/af/afcalc_20190101.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
-rewrite ^/af/afcalc_20171228.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
-rewrite ^/af/afcalc_20170101.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
-rewrite ^/af/afcalc_20130725.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
-rewrite ^/af/afcalc_20160701.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
-rewrite ^/af/afcalc_post-200907.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+# about/ redirects 
+rewrite ^/about.shtml https://www.fec.gov/about/ redirect;
+
+# about/offices/ redirects
+rewrite ^/about/offices/offices.shtml https://www.fec.gov/about/leadership-and-structure/fec-offices/ redirect;
+rewrite ^/about/offices/EEO/EEO.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+
+# af/ Admin fines redirects
 rewrite ^/af/af.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
+rewrite ^/af/af_calc.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
 rewrite ^/af/AFPRegulations.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/#legal-citations redirect;
 rewrite ^/af/pay.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/#paying-a-fine redirect;
 rewrite ^/af/payment/index.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/#paying-a-fine redirect;
 rewrite ^/af/documents/2016AFPRegulations.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=351065 redirect;
-rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
-rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/elections.html https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
-rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
-rewrite ^/pdf/1997_Enforcement_Manual.pdf https://www.fec.gov/resources/cms-content/documents/1997_enforcement_manual.pdf redirect;
-rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
-rewrite ^/pdf/2017-2018_rad_review_referral_procedures.pdf https://www.fec.gov/resources/cms-content/documents/2017-2018_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/RAD_Procedures_2015-16.pdf https://www.fec.gov/resources/cms-content/documents/2015-2016_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/RAD_Procedures_2013-14.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/RAD_Procedures.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/2016title26materialitythresholdsapproved09132016_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2016_audit_materiality_thresholds_title_26_presidential.pdf redirect;
-rewrite ^/pdf/2014AuthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_authorized.pdf redirect;
-rewrite ^/pdf/2014UnauthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_unauthorized.pdf redirect;
-rewrite ^/pdf/2012title2authmaterialitythresholdsapprvd72313_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_authorized.pdf redirect;
-rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
-rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
-rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
-rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
-rewrite ^/pdf/audit_threshold_title26_2008.pdf https://www.fec.gov/resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
-rewrite ^/pages/brochures/audit_process.pdf https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
-rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-23_EO13892.pdf redirect;
-rewrite ^/law/policy/notice_2006-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-11_EO13892.pdf redirect;
-rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
-rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/documents/respondent_guide.pdf redirect;rewrite ^/pdf/67fr05445.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2002-01_EO13892.pdf redirect;
-rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/documents/commissioners_tips_2016_EO13892.pdf redirect;
-rewrite ^press/bkgnd/fund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
-rewrite ^/pdf/record/1999/index99_1.htm https://www.fec.gov/resources/cms-content/documents/index1999.pdf redirect;
-rewrite ^/pdf/record/1998/index98_1.htm https://www.fec.gov/resources/cms-content/documents/index1998.pdf redirect;
-rewrite ^/pdf/record/1997/index97_1.htm https://www.fec.gov/resources/cms-content/documents/index1997.pdf redirect;
-rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
-rewrite ^/rad/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
+rewrite ^/af/afcalc_20190101.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_20171228.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_20170101.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_20160701.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_20130725.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+rewrite ^/af/afcalc_post-200907.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/#calculating-a-fine redirect;
+
+# agenda/ redirects
+rewrite ^/agenda/agendas.shtml https://www.fec.gov/updates/?update_type=meetings redirect;
+rewrite ^/agenda/meetings.shtml https://www.fec.gov/updates/?update_type=meetings redirect;
+
+# agenda/2016/ redirects
+rewrite ^/agenda/2016/agendaaudithearing20161206.shtml https://www.fec.gov/updates/december-6-2016-audit-hearing-open-meeting/ redirect;
+
+# agenda/2015/ redirects
+rewrite ^/agenda/2015/agenda_administrative_review_hearing20151102.shtml https://www.fec.gov/updates/november-2-2015-administrative-review-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2015/agendaaudithearing20150506.shtml https://www.fec.gov/updates/rescheduled-to-wednesday-may-13-2015-at-1000-ammay-6-2015-audit-hearing-open-meeting/ redirect;
+
+# agenda/2014/ redirects
+rewrite ^/agenda/2014/agendaaudithearing20141120.shtml https://www.fec.gov/updates/november-20-2014-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20140612.shtml https://www.fec.gov/updates/june-12-2014-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20140423.shtml https://www.fec.gov/updates/april-23-2014audit-hearing-open-meeting/ redirect;
+
+# agenda/2012/ redirects
+rewrite ^/agenda/2012/agendaaudithearing20120823.shtml https://www.fec.gov/updates/august-23-2012-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2012/agendaaudithearing20120627.shtml https://www.fec.gov/updates/june-27-2012-open-meeting/ redirect;
+
+# agenda/2010/ redirects
+rewrite ^/agenda/2010/oral_hearing20100120.shtml https://www.fec.gov/updates/oral-hearing-postponed-open-meeting/ redirect;
+
+# agenda/
+rewrite ^/agenda/2009/oral_hearing20091104.shtml https://www.fec.gov/updates/november-4-2009-open-meeting/ redirect;
+
+# ans/ Quick answers redirects
+rewrite ^/ans/answers.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_candidate.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
+rewrite ^/ans/answers_compliance.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
+rewrite ^/ans/answers_filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/ans/answers_pac.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_party.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+
+# audits/ redirects
+rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
+
+# auditsearch/ redirects
+rewrite ^/auditsearch/auditsearch.do https://www.fec.gov/legal-resources/enforcement/audit-search/ redirect;
+
+# calendar/ redirects
+rewrite ^/calendar/calendar.shtml https://www.fec.gov/calendar/ redirect;
+
+# data/ redirects
+rewrite ^/data/DataCatalog.do https://www.fec.gov/data/ redirect;
+
+# directives/ redirects
+rewrite ^/directives/CommissionDirectives.shtml https://www.fec.gov/about/leadership-and-structure/#commission-directives-and-policy redirect;
+
+# disclosure/ redirects
+rewrite ^/disclosure/pacSummary.do https://www.fec.gov/data/browse-data/?tab=committees redirect;
+rewrite ^/disclosure/partySummary.do https://www.fec.gov/data/browse-data/?tab=committees redirect;
+rewrite ^/disclosurehs/hsnational.do https://www.fec.gov/data/browse-data/?tab=candidates redirect;
+rewrite ^/disclosureie/ienational.do https://www.fec.gov/data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true redirect;
+rewrite ^/disclosureie/ienational.do?candOffice=S https://www.fec.gov/data/independent-expenditures/?data_type=processed&is_notice=true&most_recent=true&candidate_office=S redirect;
+rewrite ^/disclosurep/pnational.do https://www.fec.gov/data/candidates/president/presidential-map/ redirect;
+
+# eeo/ redirects
 rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect; 
-rewrite ^/about/offices/EEO/EEO.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
-rewrite ^/about/offices/offices.shtml https://www.fec.gov/about/leadership-and-structure/fec-offices/ redirect; 
-rewrite ^/pages/brochures/partnership.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
-rewrite ^/pages/brochures/partnership_brochure.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
-rewrite ^/pages/brochures/partnership_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
-rewrite ^/pages/brochures/delegate_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
+rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
+rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
+
+# elecfil/ redirects
+rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/electron.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/FECFileIntroPage.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/fecfile-software/ redirect;
+rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
+rewrite ^/elecfil/vendors.shtml	https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
+
+# em/ redirects
+rewrite ^/em/adr.shtml https://www.fec.gov/legal-resources/enforcement/alternative-dispute-resolution/ redirect;
+rewrite ^/em/em.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/em/mur.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/documents/respondent_guide.pdf redirect;
+
+# fecig/ redirects
+rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
+
+# general/ redirects
+rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+
+# info/ Info Division redirects
 rewrite ^/info/apptwo.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect;
 rewrite ^/info/appone.htm https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pdf/record/1996/index96_1.htm https://www.fec.gov/resources/cms-content/documents/index1996.pdf redirect; 
-rewrite ^/pdf/record/1996/index96.htm https://www.fec.gov/resources/cms-content/documents/index1996.pdf redirect; 
-rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
-rewrite ^/pages/record.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
-rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/pubrec/cfsdd/ https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
-rewrite ^/pages/statefiling.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
-rewrite ^/pages/brochures/candregis.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/ redirect;
-rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers redirect;
-rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
-rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
-rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
-rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
-rewrite ^/info/publications.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect;
-rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
-rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
-rewrite ^/pages/brochures/contrib.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect; 
-rewrite ^/pages/brochures/contributions_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
-rewrite ^/pages/brochures/contributions_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
-rewrite ^/pages/brochures/volact.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
-rewrite ^/pages/brochures/volunteer_activity_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
-rewrite ^/pages/brochures/volunteer_activity_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
-rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
-rewrite ^/pages/brochures/TestingTheWaters.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
-rewrite ^/pages/brochures/citizens.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/pages/brochures/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/pages/brochures/citngui1.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect; 
-rewrite ^/pages/brochures/contriblimits.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-limits/ redirect;
-rewrite ^/law/cfr/ej_main.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/ redirect;
-rewrite ^/law/cfr/ej_citation.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/explanations-and-justifications-citation-index/ redirect;
-rewrite ^/law/cfr/ej_toc.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-e-j-s/ redirect;
-rewrite ^/law/cfr/ej_toc_1970.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-1975-1979/ redirect;
-rewrite ^/law/cfr/ej_toc_1980.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-1980-1989-ejs/ redirect;
-rewrite ^/law/cfr/ej_toc_1990.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-1990-1999-ejs/ redirect;
-rewrite ^/law/cfr/ej_toc_2000.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-2000-2009-ejs/ redirect;
-rewrite ^/law/cfr/ej_toc_2010.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-2010-2019-ejs/ redirect;
-rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
-rewrite ^/info/guidance/debt_retirement.shtml https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
-rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/publications/fecglossary2009.pdf https://www.fec.gov/help-candidates-and-committees/guides/ redirect;
-rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/updates/testing-the-waters-for-possible-candidacy-2019/ redirect;
 rewrite ^/info/charts_cpe_2017.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice2017-02.pdf redirect;
 rewrite ^/info/charts_cpe_2016.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
 rewrite ^/info/charts_cpe_2015.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
@@ -120,170 +118,379 @@ rewrite ^/info/charts_441ad_2012.shtml https://www.fec.gov/resources/cms-content
 rewrite ^/info/charts_441ad_2011.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
 rewrite ^/info/charts_441ad_2010.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
 rewrite ^/info/charts_441ad.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2010/notice_2010-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2008/notice_2008-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2008-04.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
-rewrite ^/af/af_calc.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
-rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
-rewrite ^/info/LegislativeRecommendations1993.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect;
-rewrite ^/pages/legislative_recommendations_2004.htm https://www.fec.gov/resources/cms-content/documents/legrec2004.pdf redirect;
-rewrite ^/info/hearings.shtml https://www.fec.gov/meetings/?tab=hearings redirect;
-rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
-rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
-rewrite ^/ans/answers.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
-rewrite ^/ans/answers_compliance.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
-rewrite ^/ans/answers_pac.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/ans/answers_party.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/info/election_day_links.shtml https://www.fec.gov/introduction-campaign-finance/election-day-information/ redirect;
-rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
-rewrite ^/law/litigation/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/info/articles/debtretirement09.pdf https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
-rewrite ^/info/articles/windingdown09.pdf https://www.fec.gov/help-candidates-and-committees/winding-down-candidate-campaign/ redirect;
-rewrite ^/info/guidance/hlogabundling.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2019/ redirect;
-rewrite ^/ans/answers_candidate.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
-rewrite ^/ans/answers_filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/info/outreach.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
-rewrite ^/elecfil/electron.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/elecfil/FECFileIntroPage.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/fecfile-software/ redirect;
-rewrite ^/support/index.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/fecfile-software/ redirect;
-rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
-rewrite ^/elecfil/vendors.shtml	https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 rewrite ^/info/checkoff.htm https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#the-tax-checkoff redirect;
-rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pdf/eleccoll.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
-rewrite ^/law/feca/feca.pdf https://www.fec.gov/resources/cms-content/documents/feca.pdf redirect;
-rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
-rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
-rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;
-rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
-rewrite ^/pages/brochures/ao_brochure.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
-rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
-rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
-rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pages/brochures/checkoff.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#primary-matching-funds redirect;
-rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
-rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
-rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
-rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
-rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/ElectionDate/2018/PA__07.shtml https://transition.fec.gov/info/ElectionDate/2018/PA_07.shtml redirect;
-rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
-rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;
-rewrite ^/pdf/nongui.pdf https://www.fec.gov/resources/cms-content/documents/nongui.pdf redirect;
-rewrite ^/auditsearch/auditsearch.do http://classic.fec.gov/auditsearch/auditsearch.do redirect;
-rewrite ^/calendar/calendar.shtml http://classic.fec.gov/calendar/calendar.shtml redirect;
-rewrite ^/calendar/calendar.shtml http://classic.fec.gov/calendar/calendar.shtml redirect;
-rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;
-rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;
-rewrite ^/disclosure/pacSummary.do http://classic.fec.gov/disclosure/pacSummary.do redirect;
-rewrite ^/disclosure/partySummary.do http://classic.fec.gov/disclosure/partySummary.do redirect;
-rewrite ^/disclosurehs/hsnational.do http://classic.fec.gov/disclosurehs/hsnational.do redirect;
-rewrite ^/disclosureie/ienational.do http://classic.fec.gov/disclosureie/ienational.do redirect;
-rewrite ^/disclosureie/ienational.do?candOffice=S http://classic.fec.gov/disclosureie/ienational.do?candOffice=S redirect;
-rewrite ^/disclosurep/pnational.do http://classic.fec.gov/disclosurep/pnational.do redirect;
-rewrite ^/support/GettingStartedManualUpdate-A_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
-rewrite ^/support/Getting_Started_Manual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
-rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
-rewrite ^/portal/download.shtml http://classic.fec.gov/portal/download.shtml redirect;
-rewrite ^/portal/graphic_presentation.shtml http://classic.fec.gov/portal/graphic_presentation.shtml redirect;
-rewrite ^/portal/searchable.shtml http://classic.fec.gov/portal/searchable.shtml redirect;
-rewrite ^/privacy.shtml https://github.com/fecgov/policy/blob/master/privacy_policy_README.md redirect;
+rewrite ^/info/compliance.shtml /index.html redirect;
+rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
+rewrite ^/info/election_day_links.shtml https://www.fec.gov/introduction-campaign-finance/election-day-information/ redirect;
 rewrite ^/info/filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/info/forms.shtml https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
-rewrite ^/about.shtml https://www.fec.gov/about/ redirect;
-rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
-rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;
-rewrite ^/directives/CommissionDirectives.shtml https://www.fec.gov/about/leadership-and-structure/#commission-directives-and-policy redirect;
-rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissioners/ redirect;
+rewrite ^/info/hearings.shtml https://www.fec.gov/meetings/?tab=hearings redirect;
+rewrite ^/info/LegislativeRecommendations1993.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect;
+rewrite ^/info/legrec.htm https://www.fec.gov/resources/cms-content/documents/legrec1997.pdf;
 rewrite ^/info/mission.shtml https://www.fec.gov/about/mission-and-history/ redirect;
-rewrite ^/pages/anreport.shtml https://www.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/ redirect;
-rewrite ^/pages/procure/procure.shtml https://www.fec.gov/about/reports-about-fec/procurement-and-contracting/ redirect;
-rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
-rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
+rewrite ^/info/outreach.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/publications.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect;
 rewrite ^/info/report_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/pages/contact.shtml https://www.fec.gov/contact-us/ redirect;
-rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
-rewrite ^/pages/brochures/bestpractices.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
-rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
-rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
-rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
-rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
-rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
-rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
-rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
-rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
-rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
-rewrite ^/pages/brochures/TestingtheWaters.shtml https://www.fec.gov/updates/testing-the-waters-for-possible-candidacy-2019/ redirect;
-rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TipsforTreasurers.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+
+# info/ElectionDate/ Compliance map redirect
+rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+
+# info/articles/ redirects
+rewrite ^/info/articles/debtretirement09.pdf https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
+rewrite ^/info/articles/windingdown09.pdf https://www.fec.gov/help-candidates-and-committees/winding-down-candidate-campaign/ redirect;
+
+# info/guidance/ redirects
+rewrite ^/info/guidance/debt_retirement.shtml https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
+rewrite ^/info/guidance/hlogabundling.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
+rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
+
+# info/publications/ redirects
+rewrite ^/info/publications/fecglossary2009.pdf https://www.fec.gov/help-candidates-and-committees/guides/ redirect;
+
+# law/ redirects
 rewrite ^/law/draftaos.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-02.pdf https://www.fec.gov/documents/158/fedreg_notice2017-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-03.pdf https://www.fec.gov/documents/159/fedreg_notice2017-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-04.pdf https://www.fec.gov/documents/160/fedreg_notice2017-04.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-05.pdf https://www.fec.gov/documents/157/fedreg_notice2017-05.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-06.pdf https://www.fec.gov/documents/156/fedreg_notice2017-06.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-07.pdf https://www.fec.gov/documents/155/fedreg_notice2017-07.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-08.pdf https://www.fec.gov/documents/154/fedreg_notice2017-08.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2017/notice2017-10.pdf https://www.fec.gov/documents/153/fedreg_notice2017-10.pdf redirect;
+rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
+rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/fundraising-other-candidates-committees/ redirect;
+rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
+
+# law/cfr/ redirects
+rewrite ^/law/cfr/cfr.shtml https://www.fec.gov/regulations redirect;
+rewrite ^/law/cfr/ej_citation.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/explanations-and-justifications-citation-index/ redirect;
+rewrite ^/law/cfr/ej_main.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/ redirect;
+rewrite ^/law/cfr/ej_toc.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-e-j-s/ redirect;
+rewrite ^/law/cfr/ej_toc_1970.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-1975-1979/ redirect;
+rewrite ^/law/cfr/ej_toc_1980.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-1980-1989-ejs/ redirect;
+rewrite ^/law/cfr/ej_toc_1990.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-1990-1999-ejs/ redirect;
+rewrite ^/law/cfr/ej_toc_2000.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-2000-2009-ejs/ redirect;
+rewrite ^/law/cfr/ej_toc_2010.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-2010-2019-ejs/ redirect;
+
+# law/cfr/ej_compilation/2017/ redirects
 rewrite ^/law/cfr/ej_compilation/2017/notice2017-11.pdf https://www.fec.gov/documents/152/fedreg_notice2017-11.pdf redirect;
-rewrite ^/em/em.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
-rewrite ^/em/mur.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
-rewrite ^/pages/brochures/admin_fines.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
-rewrite ^/em/adr.shtml https://www.fec.gov/legal-resources/enforcement/alternative-dispute-resolution/ redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-10.pdf https://www.fec.gov/documents/153/fedreg_notice2017-10.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-08.pdf https://www.fec.gov/documents/154/fedreg_notice2017-08.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-07.pdf https://www.fec.gov/documents/155/fedreg_notice2017-07.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-06.pdf https://www.fec.gov/documents/156/fedreg_notice2017-06.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-05.pdf https://www.fec.gov/documents/157/fedreg_notice2017-05.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-04.pdf https://www.fec.gov/documents/160/fedreg_notice2017-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-03.pdf https://www.fec.gov/documents/159/fedreg_notice2017-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2017/notice2017-02.pdf https://www.fec.gov/documents/158/fedreg_notice2017-02.pdf redirect;
+
+# law/cfr/ej_compilation/2016/ redirects
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
+
+# law/cfr/ej_compilation/2015/ redirects
+rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
+
+# law/cfr/ej_compilation/2014/ redirects
+rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
+
+# law/cfr/ej_compilation/2013/ redirects
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
+
+# law/cfr/ej_compilation/2012/ redirects
+rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
+
+# law/cfr/ej_compilation/2011/ redirects
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
+
+# law/cfr/ej_compilation/2010/ redirects
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
+
+# law/cfr/ej_compilation/2009/ redirects
+rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+
+# law/cfr/ej_compilation/2008/ redirects
+rewrite ^/law/cfr/ej_compilation/2008/notice_2008-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2008-04.pdf redirect;
+
+# law/cfr/ej_compilation/2007/ redirects
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
+
+# law/cfr/ej_compilation/2006/ redirects
+rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
+
+# law/cfr/ej_compilation/2005/ redirects
+rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
+
+# law/feca/ redirects
+rewrite ^/law/feca/feca.pdf https://www.fec.gov/resources/cms-content/documents/feca.pdf redirect;
 rewrite ^/law/feca/feca.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
+
+# law/litigation/ redirects
+rewrite ^/law/litigation/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+
+# law/policy/ redirects
+rewrite ^/law/policy/notice_2006-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-11_EO13892.pdf redirect;
+rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-23_EO13892.pdf redirect;
+
+# law/policy/enforcement/ redirects
+rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
+
+# law/policy/guidance redirects
+rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
+rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
+rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
+
+# Main directory redirects
+rewrite ^/elections.html https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pindex.shtml https://www.fec.gov/data/ redirect;
+rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
+
+# open/ redirects
+rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
+rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
+
+# pages/ redirects
+rewrite ^/pages/anreport.shtml https://www.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/ redirect;
+rewrite ^/pages/contact.shtml https://www.fec.gov/contact-us/ redirect;
+rewrite ^/pages/legislative_recommendations_2004.htm https://www.fec.gov/resources/cms-content/documents/legrec2004.pdf redirect;
+rewrite ^/pages/record.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
+rewrite ^/pages/statefiling.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
+
+# pages/bcra/ redirects
+rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
+rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
+rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
+rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
+
+# pages/budget/ redirects
+rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
+rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
+
+# pages/brochures redirects
+rewrite ^/pages/brochures/admin_fines.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
+rewrite ^/pages/brochures/ao_brochure.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
+rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
+rewrite ^/pages/brochures/audit_process.pdf https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;
+rewrite ^/pages/brochures/bestpractices.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
+rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
+rewrite ^/pages/brochures/candregis.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/ redirect;
+rewrite ^/pages/brochures/checkoff.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#primary-matching-funds redirect;
+rewrite ^/pages/brochures/citizens.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/pages/brochures/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/pages/brochures/citngui1.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
+rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
+rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
+rewrite ^/pages/brochures/contrib.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
+rewrite ^/pages/brochures/contriblimits.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-limits/ redirect;
+rewrite ^/pages/brochures/contributions_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
+rewrite ^/pages/brochures/contributions_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
+rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
+rewrite ^/pages/brochures/delegate_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
+rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
+rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
+rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
+rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
+rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
+rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
+rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
+rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers redirect;
+rewrite ^/pages/brochures/partnership.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
+rewrite ^/pages/brochures/partnership_brochure.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
+rewrite ^/pages/brochures/partnership_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
+rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
+rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
+rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
+rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
+rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
+rewrite ^/pages/brochures/TestingTheWaters.shtml 
+https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
+rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
+rewrite ^/pages/brochures/volact.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/volunteer_activity_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/volunteer_activity_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+
+# pages/fecrecord/ redirects
+rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
+
+# pages/hearings/ redirects
+rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
+
+# pages/jobs/ redirects
+rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;
+
+# pages/procure redirects
+rewrite ^/pages/procure/procure.shtml https://www.fec.gov/about/reports-about-fec/procurement-and-contracting/ redirect;
+
+# pdf/ Audit thresholds redirects
+rewrite ^/pdf/2016title26materialitythresholdsapproved09132016_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2016_audit_materiality_thresholds_title_26_presidential.pdf redirect;
+rewrite ^/pdf/2014AuthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_authorized.pdf redirect;
+rewrite ^/pdf/2014UnauthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_unauthorized.pdf redirect;
+rewrite ^/pdf/2012title2authmaterialitythresholdsapprvd72313_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_authorized.pdf redirect;
+rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
+rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
+rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
+rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
+rewrite ^/pdf/audit_threshold_title26_2008.pdf https://www.fec.gov/resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
+
+# pdf/forms/ redirects
+rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
+
+# pdf/ general redirects
+rewrite ^/pdf/67fr05445.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2002-01_EO13892.pdf redirect;
+rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
+rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/documents/commissioners_tips_2016_EO13892.pdf redirect;
+rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
+rewrite ^/pdf/eleccoll.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
+
+# pdf/ Campaign Guide redirects 
+rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
+rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
+rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;
+rewrite ^/pdf/nongui.pdf https://www.fec.gov/resources/cms-content/documents/nongui.pdf redirect;
+
+# pdf/ RAD Procedures redirects
+rewrite ^/pdf/2017-2018_rad_review_referral_procedures.pdf https://www.fec.gov/resources/cms-content/documents/2017-2018_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures_2015-16.pdf https://www.fec.gov/resources/cms-content/documents/2015-2016_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures_2013-14.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
+ 
+# pdf/Record redirects
+rewrite ^/pdf/record/1999/index99_1.htm https://www.fec.gov/resources/cms-content/documents/index1999.pdf redirect;
+rewrite ^/pdf/record/1998/index98_1.htm https://www.fec.gov/resources/cms-content/documents/index1998.pdf redirect;
+rewrite ^/pdf/record/1997/index97_1.htm https://www.fec.gov/resources/cms-content/documents/index1997.pdf redirect;
+rewrite ^/pdf/record/1996/index96_1.htm https://www.fec.gov/resources/cms-content/documents/index1996.pdf redirect; 
+rewrite ^/pdf/record/1996/index96.htm https://www.fec.gov/resources/cms-content/documents/index1996.pdf redirect; 
+
+# portal/ redirects
+rewrite ^/portal/download.shtml https://www.fec.gov/data/browse-data/?tab=bulk-data redirect;
+rewrite ^/portal/graphic_presentation.shtml https://www.fec.gov/data/ redirect;
+rewrite ^/portal/searchable.shtml https://www.fec.gov/data/ redirect;
+
+# press/ redirects
+rewrite ^/press/foia.shtml https://www.fec.gov/freedom-information-act/ redirect;
 rewrite ^/press/index.shtml https://www.fec.gov/press/ redirect;
+rewrite ^/press/news_releases.shtml https://www.fec.gov/updates/?update_type=press-release redirect;
 rewrite ^/press/press_contacts.shtml https://www.fec.gov/press/#contact redirect;
 rewrite ^/press/resources_for_reporters.shtml https://www.fec.gov/press/resources-journalists/ redirect;
-rewrite ^/law/cfr/cfr.shtml https://www.fec.gov/regulations redirect;
-rewrite ^/agenda/meetings.shtml https://www.fec.gov/updates/?update_type=meetings redirect;
-rewrite ^/agenda/agendas.shtml https://www.fec.gov/updates/?update_type=meetings redirect;
-rewrite ^/agenda/2016/agendaaudithearing20161206.shtml https://www.fec.gov/updates/december-6-2016-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2015/agendaaudithearing20150506.shtml https://www.fec.gov/updates/rescheduled-to-wednesday-may-13-2015-at-1000-ammay-6-2015-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2014/agendaaudithearing20141120.shtml https://www.fec.gov/updates/november-20-2014-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2014/agendaaudithearing20140612.shtml https://www.fec.gov/updates/june-12-2014-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2014/agendaaudithearing20140423.shtml https://www.fec.gov/updates/april-23-2014audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2012/agendaaudithearing20120823.shtml https://www.fec.gov/updates/august-23-2012-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2012/agendaaudithearing20120627.shtml https://www.fec.gov/updates/june-27-2012-open-meeting/ redirect;
-rewrite ^/agenda/2010/oral_hearing20100120.shtml https://www.fec.gov/updates/oral-hearing-postponed-open-meeting/ redirect;
-rewrite ^/agenda/2009/oral_hearing20091104.shtml https://www.fec.gov/updates/november-4-2009-open-meeting/ redirect;
-rewrite ^/agenda/2015/agenda_administrative_review_hearing20151102.shtml https://www.fec.gov/updates/november-2-2015-administrative-review-hearing-open-meeting/ redirect;
-rewrite ^/press/news_releases.shtml https://www.fec.gov/updates/?update_type=press-release redirect;
-rewrite ^/info/TipsforTreasurers.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/updates/?update_type=tips-for-treasurers https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/press/weekly_digests.shtml https://www.fec.gov/updates/?update_type=weekly-digest redirect;
-rewrite ^/info/compliance.shtml /index.html redirect;
-rewrite ^/press/foia.shtml https://www.fec.gov/freedom-information-act/ redirect;
+
+# press/bkgnd/ redirects
+rewrite ^press/bkgnd/fund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+
+# privacy/ redirect
+rewrite ^/privacy.shtml https://www.fec.gov/about/privacy-and-security-policy/ redirect;
+
+# pubrec/ redirects
+rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+
+# pubrec/cfsdd/ redirects
+rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
+rewrite ^/pubrec/cfsdd/ https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
+rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
+
+# rad/ redirects
 rewrite ^/rad/index.shtml /rad/index.html redirect;
+
+# rad/candidates/documents/ redirects
 rewrite ^/rad/candidates/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
-rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resources/ redirect;
-rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
-rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
-rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
-rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
-rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
+
+# rad/documents/ redirects
+rewrite ^/rad/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
+
+# support/ redirects
+rewrite ^/support/GettingStartedManual_A.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
+rewrite ^/support/GettingStartedManualUpdate-A_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
+rewrite ^/support/Getting_Started_Manual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
+rewrite ^/support/GettingStartedManualIEForm5_6.23.16-1.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
+rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
+rewrite ^/support/GettingStartedManual_U.pdf https://www.fec.gov/resources/cms-content/documents/GettingStarted_FECFileManual_pac-party.pdf redirect;
+rewrite ^/support/index.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/fecfile-software/ redirect;
+
 
 #This section is for broader redirects
+
+# agenda/ broader redirects
+rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
+rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;
+rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1.pdf redirect;
+rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1.pdf redirect;
+rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
+rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
+
+# audio/ broader redirects
+rewrite ^/audio/([0-9]+)/(.*) https://www.fec.gov/resources/audio/$1/$2 redirect;
+
+# auditsearch/ broader redirects
+rewrite ^/auditsearch/(.*) https://www.fec.gov/legal-resources/enforcement/audit-search/ redirect;
+
+# data/ broader redirects
+rewrite ^/data/(.*) https://www.fec.gov/data/ redirect;
+
+# disclosure broader redirects
+rewrite ^/disclosure_data/(.*) https://www.fec.gov/data/ redirect;
+rewrite ^/disclosurehs/(.*) https://www.fec.gov/data/browse-data/?tab=candidates redirect;
+rewrite ^/disclosureie/(.*) https://www.fec.gov/data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true redirect;
+rewrite ^/disclosurep/(.*) https://www.fec.gov/data/candidates/president/ redirect;
+
+# fecig/ broader redirects
+rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
+rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
+
+# fecletter/ broader redirects
+rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;
+
+# info/ broader redirects
+rewrite ^/info/articles/(.*) https://www.fec.gov/updates/ redirect;
+rewrite ^/info/conference_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/conferences/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/presentations/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/documents(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/downloads/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/ElectionDate/(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/LegislativeRecommendations([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+rewrite ^/info/roundtables/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/roundtable_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treasurers$1 redirect;
+
+# law/ broader redirects
+rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+
+# members/ broader redirects
+rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissioners/ redirect;
+
+# MUR/ broader redirects
+rewrite ^/MUR/.* https://www.fec.gov/data/legal/search/enforcement/ redirect;
+
+# pdf/ broader redirects
+rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/about-fec/reports/ar$1.pdf redirect;
+rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
+
+# portal/ broader redirects
+rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;
+
+# /pubrec/ broader redirects
+rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2016/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -303,46 +510,9 @@ rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/e
 rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/info/articles/(.*) https://www.fec.gov/updates/ redirect; 
-rewrite ^/info/presentations/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/downloads/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/documents(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/roundtable_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/roundtables/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/conference_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/conferences/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/ElectionDate/(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
-rewrite ^/info/legrec.htm https://www.fec.gov/resources/cms-content/documents/legrec1997.pdf;
-rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/info/LegislativeRecommendations([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/about-fec/reports/ar$1.pdf redirect;
-rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
-rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
-rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treasurers$1 redirect;
-rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
-rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
-rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;
-rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1.pdf redirect;
-rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1.pdf redirect;
-rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
-rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
-rewrite ^/audio/([0-9]+)/(.*) https://www.fec.gov/resources/audio/$1/$2 redirect;
-rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;
-rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
-rewrite ^/portal/(.*) http://classic.fec.gov/portal/$1 redirect;
-rewrite ^/disclosurep/(.*) http://classic.fec.gov/disclosurep/$1 redirect;
-rewrite ^/disclosurehs/(.*) http://classic.fec.gov/disclosurehs/$1 redirect;
-rewrite ^/disclosureie/(.*) http://classic.fec.gov/disclosureie/$1 redirect;
-rewrite ^/data/(.*) http://classic.fec.gov/data/$1 redirect;
-rewrite ^/auditsearch/(.*) http://classic.fec.gov/auditsearch/$1 redirect;
+
+# sunshine/ broader redirects
 rewrite ^/sunshine/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/sunshine-notices/$1/$2.pdf redirect;
-rewrite ^/MUR/.* http://classic.fec.gov/MUR/ redirect;
-rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 
 # Captures all dates of format agenda/YYYY/agendaYYYYMMDD
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})01([0-9]{2}).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;


### PR DESCRIPTION
Clean-up:
Updating old classic redirects to point to fec.gov
Eliminating duplicates
Adding bumpers and categories
Alphabetizing within categories.

Adds the following pubrec/ redirects:
![image](https://user-images.githubusercontent.com/24437369/87161722-eae34c80-c292-11ea-8c92-68a1334322d4.png)

Adds a redirect from /elecfil/passwords.html to https://webforms.fec.gov/psa/getstarted.htm