### PR TITLE
 Redirect comments on policy pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -474,13 +474,35 @@ rewrite ^/law/litigation/citizens_guide_brochure.pdf https://www.fec.gov/introdu
 rewrite ^/law/policy/notice_2006-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-11_EO13892.pdf redirect;
 rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-23_EO13892.pdf redirect;
 
+# law/policy/embezzle/ redirects 
+rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
+
 # law/policy/enforcement/ redirects
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
+rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy/comments-received-enforcement-process-2013/ redirect;
 
-# law/policy/guidance redirects
+# law/policy/guidance/ redirects
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
 rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
+
+# law/policy/internet09/ redirects
+rewrite ^/law/policy/internet09/082109websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/8-21-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/072909websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/072709websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-27-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/072109websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/072009websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-20-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/071809websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-18-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/071709websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-17-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/071609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-16-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/071409websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-14-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/070809websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-8-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/070609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-6-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/070109websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-1-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-29-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-29-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-28-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-28-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-27-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-27-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-26-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-26-09websitecomments.pdf redirect;
 
 # Main directory redirects
 rewrite ^/elections.html https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -565,6 +587,7 @@ rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-arc
 
 # pages/hearings/ redirects
 rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
+rewrite ^/pages/hearings/internethearingcomments.shtml https://www.fec.gov/legal-resources/policy/website-internet-communications-improvement-initiative-comments/ redirect;
 
 # pages/jobs/ redirects
 rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;
@@ -733,6 +756,12 @@ rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents
 # law/cfr/ej_compilation/ broader redirects
 rewrite ^/law/cfr/ej_compilation/1976/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 rewrite ^/law/cfr/ej_compilation/1975/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+
+# /law/policy/embezzle/ broader redirects
+rewrite ^/law/policy/embezzle/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+
+# law/policy/enforcement/2013/ broader redirects 
+rewrite ^/law/policy/enforcement/2013/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 
 # members/ broader redirects
 rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissioners/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -532,6 +532,7 @@ rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/
 
 # pages/brochures redirects
 rewrite ^/pages/brochures/admin_fines.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
+rewrite ^/pages/brochures/adr.shtml https://www.fec.gov/legal-resources/enforcement/alternative-dispute-resolution/ redirect;
 rewrite ^/pages/brochures/ao_brochure.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
 rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
 rewrite ^/pages/brochures/audit_process.pdf https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;


### PR DESCRIPTION
The redirects for 132. have been plugged in for the Enforcement Process, Embezzle, and Internet hearings.  