### PR TITLE
Fixed syntax for transition redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -490,7 +490,7 @@ rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.
 
 # law/policy/internet09/ redirects
 rewrite ^/law/policy/internet09/crpcomment082109.pdf https://www.fec.gov/resources/cms-content/documents/8-21-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/westcomments072909.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect
+rewrite ^/law/policy/internet09/westcomments072909.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/houghtalingcomment072709.pdf https://www.fec.gov/resources/cms-content/documents/7-27-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072009.pdf https://www.fec.gov/resources/cms-content/documents/7-20-09websitecomments.pdf redirect;


### PR DESCRIPTION
I missed the terminating semicolon during code review, @kathycarothers can you please backfill this in by merging this PR? Thanks!