### PR TITLE
Implements 2009 agency procedures page and hearing-related redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -480,7 +480,9 @@ rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.g
 # law/policy/enforcement/ redirects
 rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy/comments-received-enforcement-process-2013/ redirect;
 rewrite ^/law/policy/enforcement/2013/progressivesunited2.pdf https://www.fec.gov/resources/legal-resources/enforcement/policy/progressivesunited2.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
 rewrite ^/law/policy/enforcement/hearing/notice2013-01.pdf https://www.fec.gov/resources/cms-content/documents/notice2013-01.pdf redirect;
+rewrite ^/law/policy/enforcement/notice_2008-13.pdf https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf redirect;
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
 
 # law/policy/guidance/ redirects
@@ -732,8 +734,8 @@ rewrite ^/elecfil/authorized_manual/(.*) https://efilingapps.fec.gov/fecfiledoc/
 rewrite ^/elecfil/formats/(.*) https://efilingapps.fec.gov/registration/softwarelogs.htm redirect;
 
 # fecig/ broader redirects
-rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1 redirect;
-rewrite "^/fecig/(.*)" https://www.fec.gov/office-inspector-general/ redirect;
+rewrite ^/fecig/documents/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+rewrite ^/fecig/(.*) https://www.fec.gov/office-inspector-general/ redirect;
 
 # fecletter/ broader redirects
 rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;
@@ -763,8 +765,9 @@ rewrite ^/law/cfr/ej_compilation/1975/(.*) https://www.fec.gov/resources/cms-con
 # /law/policy/embezzle/ broader redirects
 rewrite ^/law/policy/embezzle/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 
-# law/policy/enforcement/2013/ broader redirects 
+# /law/policy/enforcement/ broader redirects 
 rewrite ^/law/policy/enforcement/2013/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+rewrite ^/law/policy/enforcement/2009/comments/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 
 # members/ broader redirects
 rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissioners/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -491,9 +491,14 @@ rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/
 rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
 
 # law/policy/internet09/ redirects
-rewrite ^/law/policy/internet09/crpcomment082109.pdf https://www.fec.gov/resources/cms-content/documents/8-21-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/westcomments072909.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/houghtalingcomment072709.pdf https://www.fec.gov/resources/cms-content/documents/7-27-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/070609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-6-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/070109websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-1-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-29-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-29-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-28-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-28-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-27-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-27-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/6-26-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-26-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/agencyhearingextract.pdf https://www.fec.gov/resources/cms-content/documents/agencyhearingextract.pdf redirect;
+rewrite ^/law/policy/internet09/cathdemhearingcomment.pdf https://www.fec.gov/resources/cms-content/documents/comm7.pdf redirect;
 rewrite ^/law/policy/internet09/comments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072009.pdf https://www.fec.gov/resources/cms-content/documents/7-20-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments071809.pdf https://www.fec.gov/resources/cms-content/documents/7-18-09websitecomments.pdf redirect;
@@ -501,12 +506,11 @@ rewrite ^/law/policy/internet09/comments071709.pdf https://www.fec.gov/resources
 rewrite ^/law/policy/internet09/comments071609.pdf https://www.fec.gov/resources/cms-content/documents/7-16-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments071409.pdf https://www.fec.gov/resources/cms-content/documents/7-14-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments070809.pdf https://www.fec.gov/resources/cms-content/documents/7-8-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/070609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-6-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/070109websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-1-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/6-29-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-29-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/6-28-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-28-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/6-27-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-27-09websitecomments.pdf redirect;
-rewrite ^/law/policy/internet09/6-26-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-26-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/crpcomment082109.pdf https://www.fec.gov/resources/cms-content/documents/8-21-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/houghtalingcomment072709.pdf https://www.fec.gov/resources/cms-content/documents/7-27-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/sunlighthearingcomment.pdf https://www.fec.gov/resources/cms-content/documents/comm28.pdf redirect;
+rewrite ^/law/policy/internet09/webmanageremails.pdf https://www.fec.gov/resources/cms-content/documents/webmanageremails.pdf redirect;
+rewrite ^/law/policy/internet09/westcomments072909.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect;
 
 # Main directory redirects
 rewrite ^/elections.html https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -533,6 +537,7 @@ rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/lega
 
 # pages/budget/ redirects
 rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
+rewrite ^/pages/budget/fy2009/FECStrategicPlan2008-2013.pdf https://www.fec.gov/resources/about-fec/reports/FECStrategicPlan2008-2013.pdf redirect;
 
 # pages/brochures redirects
 rewrite ^/pages/brochures/admin_fines.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
@@ -591,8 +596,12 @@ rewrite ^/pages/brochures/volunteer_activity_brochure_spanish.pdf https://www.fe
 rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
 
 # pages/hearings/ redirects
+rewrite ^/pages/hearings/hearingtranscript09-17-09.pdf https://www.fec.gov/resources/cms-content/documents/hearingtranscript09-17-09.pdf redirect;
+rewrite ^/pages/hearings/hearing_transcript20090825.pdf https://www.fec.gov/resources/cms-content/documents/hearing_transcript20090825.pdf redirect;
 rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
 rewrite ^/pages/hearings/internethearingcomments.shtml https://www.fec.gov/legal-resources/policy/website-internet-communications-improvement-initiative-comments/ redirect;
+rewrite ^/pages/hearings/opensession20091105.pdf https://www.fec.gov/resources/cms-content/documents/opensession20091105.pdf redirect;
+rewrite ^/pages/hearings/statusofwebsiteinitiative-bluedraftrev.pdf https://www.fec.gov/resources/updates/agendas/2009/mtgdoc0974.pdf redirect;
 
 # pages/jobs/ redirects
 rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;


### PR DESCRIPTION
Redirects for following pages were included:
FR notice: 
https://transition.fec.gov/law/policy/enforcement/notice_2008-13.pdf redirected to PDF uploaded at https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf

Comment page at https://transition.fec.gov/law/policy/enforcement/2009/comments/comments.shtml redirected to https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/

Numerous PDF files were included in broader redirect from /law/policy/enforcement/2009/comments/ to same file names at https://www.fec.gov/resources/cms-content/documents/ (See redirect spreadsheet for details.) Hoping I did this right!

Also took out some extra `"` that I noticed were in some broader IG page redirects.

Updated to add redirects related to two 2009 hearings.