### PR TITLE
Adds omitted redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -478,12 +478,16 @@ rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.go
 rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
 
 # law/policy/enforcement/ redirects
-rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy/comments-received-enforcement-process-2013/ redirect;
-rewrite ^/law/policy/enforcement/2013/progressivesunited2.pdf https://www.fec.gov/resources/legal-resources/enforcement/policy/progressivesunited2.pdf redirect;
-rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
-rewrite ^/law/policy/enforcement/hearing/notice2013-01.pdf https://www.fec.gov/resources/cms-content/documents/notice2013-01.pdf redirect;
 rewrite ^/law/policy/enforcement/notice_2008-13.pdf https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf redirect;
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
+rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy/comments-received-enforcement-process-2013/ redirect;
+rewrite ^/law/policy/enforcement/2013/progressivesunited2.pdf https://www.fec.gov/resources/legal-resources/enforcement/policy/progressivesunited2.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/01141509hearingtranscript.pdf https://www.fec.gov/resources/cms-content/documents/01141509hearingtranscript.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
+rewrite ^/law/policy/enforcement/2009/hearingrecord.pdf https://www.fec.gov/resources/cms-content/documents/hearingrecord.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/notice_2009-02.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-02.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/recommendationsummary.pdf https://www.fec.gov/resources/cms-content/documents/recommendations_summary.pdf redirect;
+rewrite ^/law/policy/enforcement/hearing/notice2013-01.pdf https://www.fec.gov/resources/cms-content/documents/notice2013-01.pdf redirect;
 
 # law/policy/guidance/ redirects
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
@@ -508,6 +512,8 @@ rewrite ^/law/policy/internet09/comments071409.pdf https://www.fec.gov/resources
 rewrite ^/law/policy/internet09/comments070809.pdf https://www.fec.gov/resources/cms-content/documents/7-8-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/crpcomment082109.pdf https://www.fec.gov/resources/cms-content/documents/8-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/houghtalingcomment072709.pdf https://www.fec.gov/resources/cms-content/documents/7-27-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/notice_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-10.pdf redirect;
+rewrite ^/law/policy/internet09/notice_2009-14.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-14.pdf redirect;
 rewrite ^/law/policy/internet09/sunlighthearingcomment.pdf https://www.fec.gov/resources/cms-content/documents/comm28.pdf redirect;
 rewrite ^/law/policy/internet09/webmanageremails.pdf https://www.fec.gov/resources/cms-content/documents/webmanageremails.pdf redirect;
 rewrite ^/law/policy/internet09/westcomments072909.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect;
@@ -585,8 +591,7 @@ rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-
 rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
 rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
-rewrite ^/pages/brochures/TestingTheWaters.shtml 
-https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
+rewrite ^/pages/brochures/TestingTheWaters.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
 rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/volact.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 rewrite ^/pages/brochures/volunteer_activity_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;


### PR DESCRIPTION
Adding some redirects for policy comment files that were inadvertently omitted the last time.

/law/policy/internet09/notice_2009-10.pdf
/law/policy/internet09/notice_2009-14.pdf
/law/policy/enforcement/2009/01141509hearingtranscript.pdf
/law/policy/enforcement/2009/hearingrecord.pdf
/law/policy/enforcement/2009/notice_2009-02.pdf
/law/policy/enforcement/2009/recommendationsummary.pdf