### PR TITLE
Adds redirect for Policy and other guidance page

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -181,6 +181,7 @@ rewrite ^/law/litigationmajor.shtml https://www.fec.gov/legal-resources/court-ca
 rewrite ^/law/litigationrecent.shtml https://www.fec.gov/legal-resources/court-cases/#ongoing-litigation redirect;
 rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
 rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/fundraising-other-candidates-committees/ redirect;
+rewrite ^/law/policy.shtml https://www.fec.gov/legal-resources/policy-other-guidance/ redirect;
 rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
 
 # law/cfr/ redirects
@@ -324,7 +325,7 @@ rewrite ^/law/cfr/ej_compilation/2002/2002-26_BCRA_Reporting.pdf https://sers.fe
 rewrite ^/law/cfr/ej_compilation/2002/2002-25_Other_Provisions.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=8982 redirect;
 rewrite ^/law/cfr/ej_compilation/2002/2002-22_Contribution_Limitations_Prohibitions.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=3182 redirect;
 rewrite ^/law/cfr/ej_compilation/2002/2002-21_FCC_Database_ECs.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=117128 redirect;
-rewrite ^law/cfr/ej_compilation/2002/2002-20_Electioneering_Communications.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=11192 redirect;
+rewrite ^/law/cfr/ej_compilation/2002/2002-20_Electioneering_Communications.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=11192 redirect;
 rewrite ^/law/cfr/ej_compilation/2002/2002-12_Reorganization_Contrib_Expend_Definition.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=44678 redirect;
 rewrite ^/law/cfr/ej_compilation/2002/2002-11_Soft_Money.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=3328 redirect;
 rewrite ^/law/cfr/ej_compilation/2002/2002-08_Brokerage_Loans.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=3096 redirect;


### PR DESCRIPTION
Redirects /law/policy.shtml to new page at https://www.fec.gov/legal-resources/policy-other-guidance/.


(Also added a / to an entry I spotted missing it.)