### PR TITLE
Implement cf cli v7, rolling deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Set the `PROXIES` environment variable to a JSON object mapping proxy routes to 
 
 Unlike the other applications, the **`master`** branch is usually deployed to all three environments, and there is no special workflow for any updates or hotfixes. However, it is best to deploy the proxy app at night because it may temporarily effect our routes and wagtail work during deploy.
 
-Before you start, make sure you have the [`autopilot` (installation instructions)](https://github.com/contraband/autopilot#installation) Cloud Foundry plugin installed.  You can check to see if you have the plugin installed by running `cf plugins` checking if `autopilot` is in the list.
+Before you start, make sure you have version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
 
-Once the plugin is installed, when you're ready to deploy any changes make sure you are on the `master` branch and have done a `git pull` so that all changes are pulled down.  Now run the following commands, where `<space>` is the desired space you'd like to deploy to (`dev`, `stage`, or `prod`):
+When you're ready to deploy any changes, make sure you are on the `master` branch and have done a `git pull` so that all changes are pulled down.  Now run the following commands, where `<space>` is the desired space you'd like to deploy to (`dev`, `stage`, or `prod`):
 
 ```sh
     cf target -s <space>
-    cf zero-downtime-push proxy -f manifest_<space>.yml
+    cf push --strategy rolling proxy -f manifest_<space>.yml
 ```
 
 When the deployment is done, be sure to test the site to make sure everything is still functioning.

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,20 +1,23 @@
 ---
-stack: cflinuxfs3
-buildpack: staticfile_buildpack
 applications:
   - name: proxy
+    instances: 1
     memory: 256M
-routes:
-  - route: fec-dev-proxy.app.cloud.gov
-  - route: dev.fec.gov
-services:
-  - fec-creds-dev
-env:
-  PROXIES: |
-    {
-      "/": "https://fec-dev-cms.app.cloud.gov",
-      "/regulations": "https://fec-dev-eregs.app.cloud.gov"
-    }
-  S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"
-  S3_TRANSITION_URL: "https://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
-  S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com"
+    disk_quota: 256M
+    routes:
+      - route: fec-dev-proxy.app.cloud.gov
+      - route: dev.fec.gov
+    stack: cflinuxfs3
+    buildpacks:
+      - staticfile_buildpack
+    services:
+      - fec-creds-dev
+    env:
+      PROXIES: |
+        {
+          "/": "https://fec-dev-cms.app.cloud.gov",
+          "/regulations": "https://fec-dev-eregs.app.cloud.gov"
+        }
+      S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"
+      S3_TRANSITION_URL: "https://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
+      S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,23 +1,25 @@
 ---
-stack: cflinuxfs3
-buildpack: staticfile_buildpack
 applications:
   - name: proxy
-    memory: 256M
-instances: 4
-routes:
-  - route: beta.fec.gov
-  - route: fec-prod-proxy.app.cloud.gov
-  - route: transition.fec.gov
-  - route: www.fec.gov
-services:
-  - fec-creds-prod
-env:
-  PROXIES: |
-    {
-      "/": "https://fec-prod-cms.app.cloud.gov",
-      "/regulations": "https://fec-prod-eregs.app.cloud.gov"
-    }
-  S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"
-  S3_TRANSITION_URL: "http://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
-  S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com"
+    instances: 4
+    memory: 512M
+    disk_quota: 256M
+    routes:
+      - route: beta.fec.gov
+      - route: fec-prod-proxy.app.cloud.gov
+      - route: transition.fec.gov
+      - route: www.fec.gov
+    stack: cflinuxfs3
+    buildpacks:
+      - staticfile_buildpack
+    services:
+      - fec-creds-prod
+    env:
+      PROXIES: |
+        {
+          "/": "https://fec-prod-cms.app.cloud.gov",
+          "/regulations": "https://fec-prod-eregs.app.cloud.gov"
+        }
+      S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"
+      S3_TRANSITION_URL: "http://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
+      S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -1,19 +1,22 @@
 ---
-stack: cflinuxfs3
-buildpack: staticfile_buildpack
 applications:
   - name: proxy
-    memory: 256M
-routes:
-  - route: fec-stage-proxy.app.cloud.gov
-  - route: stage.fec.gov
-services:
-  - fec-creds-stage
-env:
-  PROXIES: |
-    {
-      "/": "https://fec-stage-cms.app.cloud.gov",
-      "/regulations": "https://fec-stage-eregs.app.cloud.gov"
-    }
-  S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"
-  S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-d3527d7d-0344-45b5-aab6-5a39d2aa409f.s3-us-gov-west-1.amazonaws.com"
+    instances: 1
+    memory: 512M
+    disk_quota: 256M
+    routes:
+      - route: fec-stage-proxy.app.cloud.gov
+      - route: stage.fec.gov
+    stack: cflinuxfs3
+    buildpacks:
+      - staticfile_buildpack
+    services:
+      - fec-creds-stage
+    env:
+      PROXIES: |
+        {
+          "/": "https://fec-stage-cms.app.cloud.gov",
+          "/regulations": "https://fec-stage-eregs.app.cloud.gov"
+        }
+      S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"
+      S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-d3527d7d-0344-45b5-aab6-5a39d2aa409f.s3-us-gov-west-1.amazonaws.com"


### PR DESCRIPTION
Resolves #188
Resolves #140

- Specify to use `cf cli` version 7
- Reformat manifest files with newer format
- Reduce `dev` memory, increase `stage` and `prod` - max memory usage for `prod` for the past 6 months is ~170 but I set it to 512M to be extra cautious. Stage should match `prod` so I modified that value as well. 
- Specify `disk_quota` - default is `1G` and we only need `6.2M` - this doesn't impact performance, just how much space the app itself takes up.
- Implement rolling deployments, remove references to `autopilot` and `zero-downtime-push`