### PR TITLE
Connect to CMS using internal routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When you're ready to deploy any changes, make sure you are on the `master` branc
 ```sh
     cf target -s <space>
     cf push --strategy rolling proxy -f manifest_<space>.yml
+    cf add-network-policy proxy cms
 ```
 
 When the deployment is done, be sure to test the site to make sure everything is still functioning.

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -15,7 +15,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-dev-cms.app.cloud.gov",
+          "/": "http://fec-dev-cms.apps.internal:8080",
           "/regulations": "https://fec-dev-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -17,7 +17,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-prod-cms.apps.internal:8080",
+          "/": "http://fec-prod-cms.apps.internal:8080",
           "/regulations": "https://fec-prod-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -17,7 +17,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-prod-cms.app.cloud.gov",
+          "/": "https://fec-prod-cms.apps.internal:8080",
           "/regulations": "https://fec-prod-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -15,7 +15,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-stage-cms.app.cloud.gov",
+          "/": "https://fec-stage-cms.apps.internal:8080",
           "/regulations": "https://fec-stage-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -15,7 +15,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-stage-cms.apps.internal:8080",
+          "/": "http://fec-stage-cms.apps.internal:8080",
           "/regulations": "https://fec-stage-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"

--- a/nginx.conf
+++ b/nginx.conf
@@ -49,7 +49,8 @@ http {
 
     <% proxies.each do |path, route| %>
       location <%= path %> {
-        resolver 8.8.8.8 ipv6=off;
+        # Use BOSH DNS resolver to include internal routes
+        resolver 169.254.0.2 ipv6=off;
         set $backend "<%= route %>";
         proxy_pass $backend;
         proxy_set_header X-Forwarded-Host $host;


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-accounts/issues/316

- Update resolver to bosh and proxies to CMS `app.internal`
- Connect over `http` instead of `https` - per cloud.gov:
> Container to container networking uses an  overlay network used solely for this purpose. The Policy server is controlling access on this network. https for regular traffic is already terminated at the routers.
- Update deployment instructions to add network policy after deploy (shouldn't be required with rolling deployments but it's good to be safe)

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Routes - will allow proxy to connect to CMS on internal apps.internal route

## Reviewers

- At least two reviewers, please

## How to test

- Check out routes with `cf app cms` and see the two routes for the CMS, internal and external
- Make sure the proxy can connect by manually deploying this branch (https://github.com/fecgov/fec-proxy#deployment) and going to dev.fec.gov
- Make sure you can't access fec-dev-cms.apps.internal
- Make sure dev.fec.gov still works