### PR TITLE
Adds or updates certain transition redirects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+# CircleCI 2.0 configuration file using base image
+# Check https://circleci.com/docs/2.0/circleci-images/#circleci-base-image for more details
+version: 2.1
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:2020.01
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install CF CLI
+          command: |
+            mkdir -p $HOME/bin
+            export PATH=$HOME/bin:$PATH
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            cf install-plugin autopilot -f -r CF-Community
+
+      - deploy:
+          name: Deploy Proxy
+          command: |
+            export PATH=$HOME/bin:$PATH
+            ./bin/cf_deploy.sh proxy fec-beta-fec $CIRCLE_BRANCH
+
+workflows:
+  version: 2.1
+  build-deploy:
+    jobs:
+      - deploy

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ When you're ready to deploy any changes, make sure you are on the `master` branc
 ```sh
     cf target -s <space>
     cf push --strategy rolling proxy -f manifest_<space>.yml
+    cf add-network-policy proxy cms
 ```
 
 When the deployment is done, be sure to test the site to make sure everything is still functioning.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Set the `PROXIES` environment variable to a JSON object mapping proxy routes to 
 
 ## Deployment
 
-Unlike the other applications, the **`master`** branch is usually deployed to all three environments, and there is no special workflow for any updates or hotfixes. However, it is best to deploy the proxy app at night because it may temporarily effect our routes and wagtail work during deploy.
+The proxy follows [other projects](https://github.com/fecgov/openFEC#creating-a-release) for the release and hotfix processes. The changes will automatically deploy when PR's are merged, or the release is cut and deployed.
+
+## Manual deployment
+
+Manual deployment is an option if there are issues with CircleCI or you want more granular control of the process.
 
 Before you start, make sure you have version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
 

--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+cloud_gov=${CF_API:-https://api.fr.cloud.gov}
+
+app=${1}
+org=${2}
+branch=${3}
+
+# Get the space that corresponds with the branch name
+if [[ ${branch} == "develop" ]]; then
+    echo "Branch is develop, deploying to dev space"
+    space="dev"
+elif [[ ${branch} == release* ]]; then
+    echo "Branch starts with release, deploying to stage space"
+    space="stage"
+elif [[ ${branch} == "master" ]]; then
+    echo "Branch is master, deploying to prod space"
+    space="prod"
+else
+# Don't deploy other branches, pass build
+    echo "No space detected"
+    exit 0
+fi
+
+manifest=manifest_${space}.yml
+
+# Get username/password for relevant space (uppercased)
+cf_username_label="FEC_CF_USERNAME_$(echo $space | tr [a-z] [A-Z])"
+cf_password_label="FEC_CF_PASSWORD_$(echo $space | tr [a-z] [A-Z])"
+
+if [[ -z ${org} || -z ${branch} || -z ${app} ]]; then
+  echo "Usage: $0  <app> <org> <branch>" >&2
+  exit 1
+fi
+
+(
+  set +x # Disable debugging
+
+  if [[ -n ${!cf_username_label} && -n ${!cf_password_label} ]]; then
+    cf api ${cloud_gov}
+    cf auth "${!cf_username_label}" "${!cf_password_label}"
+  fi
+)
+
+# Target space
+cf target -o ${org} -s ${space}
+
+# If the app exists, use rolling deployment
+if cf app ${app}; then
+  command="push --strategy rolling"
+else
+  command="push"
+fi
+
+# Deploy app
+cf ${command} ${app} -f ${manifest}
+
+# Add network policy
+cf add-network-policy proxy cms

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -15,7 +15,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-dev-cms.app.cloud.gov",
+          "/": "http://fec-dev-cms.apps.internal:8080",
           "/regulations": "https://fec-dev-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -17,7 +17,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-prod-cms.app.cloud.gov",
+          "/": "http://fec-prod-cms.apps.internal:8080",
           "/regulations": "https://fec-prod-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -15,7 +15,7 @@ applications:
     env:
       PROXIES: |
         {
-          "/": "https://fec-stage-cms.app.cloud.gov",
+          "/": "http://fec-stage-cms.apps.internal:8080",
           "/regulations": "https://fec-stage-eregs.app.cloud.gov"
         }
       S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"

--- a/nginx.conf
+++ b/nginx.conf
@@ -49,7 +49,8 @@ http {
 
     <% proxies.each do |path, route| %>
       location <%= path %> {
-        resolver 8.8.8.8 ipv6=off;
+        # Use BOSH DNS resolver to include internal routes
+        resolver 169.254.0.2 ipv6=off;
         set $backend "<%= route %>";
         proxy_pass $backend;
         proxy_set_header X-Forwarded-Host $host;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -689,6 +689,7 @@ rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/d
 rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
 rewrite ^/pdf/eleccoll.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
 rewrite ^/pdf/firsttenyearsreport.pdf https://www.fec.gov/resources/about-fec/reports/firsttenyearsreport.pdf redirect;
+rewrite ^/pdf/firsttenyears.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyears.pdf redirect;
 
 # pdf/nprm/ redirects
 rewrite ^/pdf/nprm/emilyslistrepeal/notice_2009-30.pdf https://www.fec.gov/resources/legal-resources/rulemakings/nprm/emilyslistrepeal/notice_2009-30.pdf redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -84,7 +84,7 @@ rewrite ^/disclosurep/pnational.do https://www.fec.gov/data/candidates/president
 
 # eeo/ redirects
 rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
-rewrite ^/eeo/policy_statement.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/policy_statement.shtml https://www.fec.gov/about/equal-employment-opportunity/#policies-and-statements redirect;
 rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
 rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
 

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -83,7 +83,8 @@ rewrite ^/disclosureie/ienational.do?candOffice=S https://www.fec.gov/data/indep
 rewrite ^/disclosurep/pnational.do https://www.fec.gov/data/candidates/president/presidential-map/ redirect;
 
 # eeo/ redirects
-rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect; 
+rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/policy_statement.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
 rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
 rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
 
@@ -177,6 +178,7 @@ rewrite ^/info/publications/30year.pdf https://www.fec.gov/resources/cms-content
 # law/ redirects
 rewrite ^/law/draftaos.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
 rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/law/legalconsideration.shtml https://www.fec.gov/legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
 rewrite ^/law/litigationmajor.shtml https://www.fec.gov/legal-resources/court-cases/#selected-court-cases redirect;
 rewrite ^/law/litigationrecent.shtml https://www.fec.gov/legal-resources/court-cases/#ongoing-litigation redirect;
 rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
@@ -497,7 +499,6 @@ rewrite ^/law/policy/formsrevisions2016/oconnor-formscomment.pdf https://www.fec
 rewrite ^/law/policy/iedisseminationdate/seiucomment.pdf https://www.fec.gov/resources/cms-content/documents/seiucomment.pdf redirect;
 rewrite ^/law/policy/iedisseminationdate/pomeranzcomment.pdf https://www.fec.gov/resources/cms-content/documents/pomeranzcomment.pdf redirect;
 
-
 # law/policy/embezzle/ redirects 
 rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
 
@@ -630,6 +631,7 @@ rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaig
 rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/sale_and_use_brochure.pdf https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
@@ -748,7 +750,6 @@ rewrite ^/pubrec/cfsdd/ https://www.fec.gov/introduction-campaign-finance/how-to
 rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
 
-
 # rad/ redirects
 rewrite ^/rad/index.shtml /rad/index.html redirect; 
 
@@ -795,6 +796,9 @@ rewrite ^/disclosure_data/(.*) https://www.fec.gov/data/ redirect;
 rewrite ^/disclosurehs/(.*) https://www.fec.gov/data/browse-data/?tab=candidates redirect;
 rewrite ^/disclosureie/(.*) https://www.fec.gov/data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true redirect;
 rewrite ^/disclosurep/(.*) https://www.fec.gov/data/candidates/president/ redirect;
+
+# eeo broader redirects
+rewrite ^/eeo/(.*).pdf https://www.fec.gov/about/equal-employment-opportunity/ redirect;
 
 # elecfil/ broader redirects
 rewrite ^/elecfil/authorized_manual/(.*) https://efilingapps.fec.gov/fecfiledoc/fecfiledoc.pdf redirect;
@@ -862,10 +866,11 @@ rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissi
 rewrite ^/MUR/.* https://www.fec.gov/data/legal/search/enforcement/ redirect;
 
 # pdf/ broader redirects
-rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/about-fec/reports/ar$1.pdf redirect;
+rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
+rewrite ^/pdf/record/(.*).pdf https://www.fec.gov/resources/cms-content/documents/resources/record/$1.pdf redirect;
 
 # portal/ broader redirects
 rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -241,6 +241,17 @@ rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/fin
 rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
 rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
 
+# Redirects for /resources/about-fec/
+rewrite ^/resources/about-fec/reports/20year.pdf https://www.fec.gov/resources/cms-content/documents/20year.pdf redirect;
+rewrite ^/resources/about-fec/reports/30year.pdf https://www.fec.gov/resources/cms-content/documents/30year.pdf redirect;
+rewrite ^/resources/about-fec/reports/firsttenyearsreport.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
+rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resources/cms-content/documents/cbr_app_d.pdf redirect;
+rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
+
+# Redirects for /resources/foia/
+rewrite ^/resources/foia/chieffoiareport2016.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2016.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2017.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2017.pdf redirect;
+
 # This section is for broader redirects
 rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -276,7 +287,7 @@ rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/info/LegislativeRecommendations([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/about-fec/reports/ar$1.pdf redirect;
+rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
 rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;
 rewrite ^/fecviewer/CommitteeDetailFilings.do /data/?search=$arg_candidateCommitteeId redirect;
 rewrite ^/pdf/nprm/(.*) /resources/legal-resources/rulemakings/nprm/$1 redirect;
@@ -317,6 +328,10 @@ rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agen
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
+
+# Broader redirects for resources/about-fec/
+rewrite ^/resources/about-fec/reports/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
+
 
 # Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format.
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;


### PR DESCRIPTION
Updates broader transition redirect for annual reports to go from /about-fec/reports/ to /resources/cms-content/documents/
Adds redirects:
Old EEO page /eeo/policy_statement.shtml to https://www.fec.gov/about/equal-employment-opportunity/
Old EEO directory (broader)	/eeo/(.*).pdf to https://www.fec.gov/about/equal-employment-opportunity/
Old Records on Transition (broader) /pdf/record/(.*).pdf to https://www.fec.gov/resources/cms-content/documents/resources/record/$1.pdf
Older version of sale or use brochure /pages/brochures/sale_and_use_brochure.pdf to https://www.fec.gov/updates/sale-or-use-contributor-information/
Old Requests for legal consideration	/law/legalconsideration.shtml to https://www.fec.gov/legal-resources/policy-other-guidance/requests-legal-consideration/