### PR TITLE
Updates www redirects for PDFs made accessible

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -241,6 +241,17 @@ rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/fin
 rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
 rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
 
+# Redirects for /resources/about-fec/
+rewrite ^/resources/about-fec/reports/20year.pdf https://www.fec.gov/resources/cms-content/documents/20year.pdf redirect;
+rewrite ^/resources/about-fec/reports/30year.pdf https://www.fec.gov/resources/cms-content/documents/30year.pdf redirect;
+rewrite ^/resources/about-fec/reports/firsttenyearsreport.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
+rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resources/cms-content/documents/cbr_app_d.pdf redirect;
+rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
+
+# Redirects for /resources/foia/
+rewrite ^/resources/foia/chieffoiareport2016.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2016.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2017.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2017.pdf redirect;
+
 # This section is for broader redirects
 rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -276,7 +287,7 @@ rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/info/LegislativeRecommendations([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/about-fec/reports/ar$1.pdf redirect;
+rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
 rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;
 rewrite ^/fecviewer/CommitteeDetailFilings.do /data/?search=$arg_candidateCommitteeId redirect;
 rewrite ^/pdf/nprm/(.*) /resources/legal-resources/rulemakings/nprm/$1 redirect;
@@ -317,6 +328,10 @@ rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agen
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
+
+# Broader redirects for resources/about-fec/
+rewrite ^/resources/about-fec/reports/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
+
 
 # Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format.
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;


### PR DESCRIPTION
Updates broader www redirect for annual reports to https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
Adds broader www redirect for annual reports from /resources/about-fec/reports/ar([0-9]+) to https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
Adds www redirects for FOIA PDFs from /resources/foia/ to /resources/cms-content/documents/
Adds www redirects for agency report PDFs from /resources/about-fec/ to  /resources/cms-content/documents/