### PR TITLE
Add CircleCI integration for proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,6 @@ jobs:
 
 workflows:
   version: 2.1
-  manual-appoval-and-deploy:
+  build-deploy:
     jobs:
-      - manual-approval:
-          type: approval
-      # Deploy won't run without manual approval
-      # See https://circleci.com/docs/2.0/workflows/#holding-a-workflow-for-a-manual-approval
-      - deploy:
-          requires:
-            - manual-approval
+      - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+# CircleCI 2.0 configuration file using base image
+# Check https://circleci.com/docs/2.0/circleci-images/#circleci-base-image for more details
+version: 2.1
+jobs:
+  deploy:
+    docker:
+      - image: cimg/base:2020.01
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install CF CLI
+          command: |
+            mkdir -p $HOME/bin
+            export PATH=$HOME/bin:$PATH
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            cf install-plugin autopilot -f -r CF-Community
+
+      - deploy:
+          name: Deploy Proxy
+          command: |
+            export PATH=$HOME/bin:$PATH
+            ./bin/cf_deploy.sh proxy fec-beta-fec $CIRCLE_BRANCH
+
+workflows:
+  version: 2.1
+  manual-appoval-and-deploy:
+    jobs:
+      - manual-approval:
+          type: approval
+      # Deploy won't run without manual approval
+      # See https://circleci.com/docs/2.0/workflows/#holding-a-workflow-for-a-manual-approval
+      - deploy:
+          requires:
+            - manual-approval

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Set the `PROXIES` environment variable to a JSON object mapping proxy routes to 
 
 ## Deployment
 
-Unlike the other applications, the **`master`** branch is usually deployed to all three environments, and there is no special workflow for any updates or hotfixes. However, it is best to deploy the proxy app at night because it may temporarily effect our routes and wagtail work during deploy.
+The proxy follows [other projects](https://github.com/fecgov/openFEC#creating-a-release) for the release and hotfix processes. The changes will automatically deploy when PR's are merged, or the release is cut and deployed.
+
+However, it is best to deploy the proxy app at night because it may temporarily effect our routes and wagtail work during deploy. For this reason, builds require manual approval in CircleCI to run.
+
+## Manual deployment
 
 Before you start, make sure you have version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Set the `PROXIES` environment variable to a JSON object mapping proxy routes to 
 
 The proxy follows [other projects](https://github.com/fecgov/openFEC#creating-a-release) for the release and hotfix processes. The changes will automatically deploy when PR's are merged, or the release is cut and deployed.
 
-However, it is best to deploy the proxy app at night because it may temporarily effect our routes and wagtail work during deploy. For this reason, builds require manual approval in CircleCI to run.
-
 ## Manual deployment
+
+Manual deployment is an option if there are issues with CircleCI or you want more granular control of the process.
 
 Before you start, make sure you have version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
 

--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -x
+
+cloud_gov=${CF_API:-https://api.fr.cloud.gov}
+
+app=${1}
+org=${2}
+branch=${3}
+
+# Get the space that corresponds with the branch name
+if [[ ${branch} == "develop" ]]; then
+    echo "Branch is develop, deploying to dev space"
+    space="dev"
+elif [[ ${branch} == release* ]]; then
+    echo "Branch starts with release, deploying to stage space"
+    space="stage"
+elif [[ ${branch} == "master" ]]; then
+    echo "Branch is master, deploying to prod space"
+    space="prod"
+else
+# Don't deploy other branches, pass build
+    echo "No space detected"
+    exit 0
+fi
+
+manifest=manifest_${space}.yml
+
+# Get username/password for relevant space (uppercased)
+cf_username_label="FEC_CF_USERNAME_$(echo $space | tr [a-z] [A-Z])"
+cf_password_label="FEC_CF_PASSWORD_$(echo $space | tr [a-z] [A-Z])"
+
+if [[ -z ${org} || -z ${branch} || -z ${app} ]]; then
+  echo "Usage: $0  <app> <org> <branch>" >&2
+  exit 1
+fi
+
+(
+  set +x # Disable debugging
+
+  if [[ -n ${!cf_username_label} && -n ${!cf_password_label} ]]; then
+    cf api ${cloud_gov}
+    cf auth "${!cf_username_label}" "${!cf_password_label}"
+  fi
+)
+
+# Target space
+cf target -o ${org} -s ${space}
+
+# If the app exists, use rolling deployment
+if cf app ${app}; then
+  command="push --strategy rolling"
+else
+  command="push"
+fi
+
+# Deploy app
+cf ${command} ${app} -f ${manifest}
+
+# Add network policy
+cf add-network-policy proxy cms


### PR DESCRIPTION
Resolves #164
Resolves #199

- Add CircleCI integration for proxy (borrowed heavily from pattern-library scripts)
- Deploy to appropriate space for each branch:
`develop` ➡️  `dev` space
`release*` ➡️ `stage` space
`master` ➡️ `prod` space
`feature` ➡️ no space
- Note: in order to add CircleCI integration, the **proxy needs to be added to our release/deploy and hotfix processes**. Redirects should be merged to the `develop` branch going forward.

### Reviewers
At least two approvals, please

### How to test
- Review `bash` syntax to make sure it makes sense/looks good
- Make a copy of this branch and name it `release/<your_branch_name>` and/or add `|| ${branch} == "<your_branch_name>" ]]` to this line: https://github.com/fecgov/fec-proxy/blob/ed7387c8ac1ee68bf42b02610c9b1fcb8560406a/bin/cf_deploy.sh#L14
So it reads:
```
if [[ ${branch} == "develop" || ${branch} == "<your_branch_name>" ]]; then
```
- Push up your branch
- ~See the paused workflow in Circle~ removed manual approval step after discussing with @patphongs 
- ~**Approve the workflow** (required for build to finish)~ removed manual approval step after discussing with @patphongs 
- Your branch gets deployed to the `stage` space (or develop if you changed the dev rules above( 