### PR TITLE
Adds or updates certain transition redirects (based on new develop)

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -83,7 +83,8 @@ rewrite ^/disclosureie/ienational.do?candOffice=S https://www.fec.gov/data/indep
 rewrite ^/disclosurep/pnational.do https://www.fec.gov/data/candidates/president/presidential-map/ redirect;
 
 # eeo/ redirects
-rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect; 
+rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/policy_statement.shtml https://www.fec.gov/about/equal-employment-opportunity/#policies-and-statements redirect;
 rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
 rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
 
@@ -177,6 +178,7 @@ rewrite ^/info/publications/30year.pdf https://www.fec.gov/resources/cms-content
 # law/ redirects
 rewrite ^/law/draftaos.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
 rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/law/legalconsideration.shtml https://www.fec.gov/legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
 rewrite ^/law/litigationmajor.shtml https://www.fec.gov/legal-resources/court-cases/#selected-court-cases redirect;
 rewrite ^/law/litigationrecent.shtml https://www.fec.gov/legal-resources/court-cases/#ongoing-litigation redirect;
 rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
@@ -497,7 +499,6 @@ rewrite ^/law/policy/formsrevisions2016/oconnor-formscomment.pdf https://www.fec
 rewrite ^/law/policy/iedisseminationdate/seiucomment.pdf https://www.fec.gov/resources/cms-content/documents/seiucomment.pdf redirect;
 rewrite ^/law/policy/iedisseminationdate/pomeranzcomment.pdf https://www.fec.gov/resources/cms-content/documents/pomeranzcomment.pdf redirect;
 
-
 # law/policy/embezzle/ redirects 
 rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
 
@@ -630,6 +631,7 @@ rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaig
 rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/sale_and_use_brochure.pdf https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
@@ -687,6 +689,7 @@ rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/d
 rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
 rewrite ^/pdf/eleccoll.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
 rewrite ^/pdf/firsttenyearsreport.pdf https://www.fec.gov/resources/about-fec/reports/firsttenyearsreport.pdf redirect;
+rewrite ^/pdf/firsttenyears.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyears.pdf redirect;
 
 # pdf/nprm/ redirects
 rewrite ^/pdf/nprm/emilyslistrepeal/notice_2009-30.pdf https://www.fec.gov/resources/legal-resources/rulemakings/nprm/emilyslistrepeal/notice_2009-30.pdf redirect;
@@ -748,7 +751,6 @@ rewrite ^/pubrec/cfsdd/ https://www.fec.gov/introduction-campaign-finance/how-to
 rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
 
-
 # rad/ redirects
 rewrite ^/rad/index.shtml /rad/index.html redirect; 
 
@@ -795,6 +797,9 @@ rewrite ^/disclosure_data/(.*) https://www.fec.gov/data/ redirect;
 rewrite ^/disclosurehs/(.*) https://www.fec.gov/data/browse-data/?tab=candidates redirect;
 rewrite ^/disclosureie/(.*) https://www.fec.gov/data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true redirect;
 rewrite ^/disclosurep/(.*) https://www.fec.gov/data/candidates/president/ redirect;
+
+# eeo broader redirects
+rewrite ^/eeo/(.*).pdf https://www.fec.gov/about/equal-employment-opportunity/ redirect;
 
 # elecfil/ broader redirects
 rewrite ^/elecfil/authorized_manual/(.*) https://efilingapps.fec.gov/fecfiledoc/fecfiledoc.pdf redirect;
@@ -862,10 +867,11 @@ rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissi
 rewrite ^/MUR/.* https://www.fec.gov/data/legal/search/enforcement/ redirect;
 
 # pdf/ broader redirects
-rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/about-fec/reports/ar$1.pdf redirect;
+rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
+rewrite ^/pdf/record/(.*).pdf https://www.fec.gov/resources/cms-content/documents/resources/record/$1.pdf redirect;
 
 # portal/ broader redirects
 rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;


### PR DESCRIPTION
Updates broader transition redirect for annual reports to go from /about-fec/reports/ to /resources/cms-content/documents/
Adds redirects:
Old EEO page /eeo/policy_statement.shtml to https://www.fec.gov/about/equal-employment-opportunity/
Old EEO directory (broader)	/eeo/(.*).pdf to https://www.fec.gov/about/equal-employment-opportunity/
Old Records on Transition (broader) /pdf/record/(.*).pdf to https://www.fec.gov/resources/cms-content/documents/resources/record/$1.pdf
Older version of sale or use brochure /pages/brochures/sale_and_use_brochure.pdf to https://www.fec.gov/updates/sale-or-use-contributor-information/
Old Requests for legal consideration	/law/legalconsideration.shtml to https://www.fec.gov/legal-resources/policy-other-guidance/requests-legal-consideration/