### PR TITLE
Court case page related redirects

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -295,7 +295,10 @@ rewrite ^/pages/brochures/(.*) https://transition.fec.gov/pages/brochures/$1 red
 rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
 rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
 rewrite ^/pdf/record/(.*).pdf /resources/record/$1.pdf redirect;
-rewrite ^/law/litigation/(.*) https://transition.fec.gov/law/litigation/$1 redirect;
+rewrite ^/legal-resources/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
+rewrite ^/legal-resources/court-cases/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
+rewrite ^/law/litigation/(.*).pdf https://www.fec.gov/resources/legal-resources/litigation/$1.pdf redirect;
+rewrite ^/law/litigation/(.*) https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
 rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
 rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;


### PR DESCRIPTION
Add redirects for litigation pages to the court case page: https://www.fec.gov/legal-resources/court-cases/

Add redirects for record articles within legal-resources pathed links to go to https://www.fec.gov/resources/record/$1.pdf