### PR TITLE
Remove direct application routes

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,7 +5,6 @@ applications:
     memory: 256M
     disk_quota: 256M
     routes:
-      - route: fec-dev-proxy.app.cloud.gov
       - route: dev.fec.gov
     stack: cflinuxfs3
     buildpacks:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -6,7 +6,6 @@ applications:
     disk_quota: 256M
     routes:
       - route: beta.fec.gov
-      - route: fec-prod-proxy.app.cloud.gov
       - route: transition.fec.gov
       - route: www.fec.gov
     stack: cflinuxfs3

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -5,7 +5,6 @@ applications:
     memory: 512M
     disk_quota: 256M
     routes:
-      - route: fec-stage-proxy.app.cloud.gov
       - route: stage.fec.gov
     stack: cflinuxfs3
     buildpacks:


### PR DESCRIPTION

Partial resolution to https://github.com/fecgov/fec-accounts/issues/317

<img width="850" alt="Screen Shot 2020-11-18 at 6 26 41 PM" src="https://user-images.githubusercontent.com/31420082/99600549-a3509800-29cb-11eb-85c0-7fd717f3a7f5.png">

- Route Proxy traffic through CDN routes only
- Merge after redirect PR: https://github.com/fecgov/fec-proxy-redirect/pull/4
- Note that we'll need to manually remove the routes after deployment due to the [additive-only](https://github.com/cloudfoundry/cloud_controller_ng/issues/1866) nature of deploying with manifests. Example: `cf unmap-route proxy app.cloud.gov --hostname fec-dev-proxy`
