### PR TITLE
redirect transition campaign finance statistical summary files

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -884,6 +884,22 @@ rewrite "^/press/summaries/([0-9]{4})/ElectionCycle/([0-9]{1,2})m_PAC.shtml" htt
 rewrite "^/press/summaries/([0-9]{4})/ElectionCycle/([0-9]{1,2})m_IE_EC.shtml" https://www.fec.gov/campaign-finance-data/communication-filings-data-summary-tables/?year=$1&segment=$2 redirect;
 rewrite "^/press/summaries/([0-9]{4})/ElectionCycle/([0-9]{1,2})m_IE.shtml" https://www.fec.gov/campaign-finance-data/communication-filings-data-summary-tables/?year=$1&segment=$2 redirect;
 
+# /press/summaries/ pdf and xls files broader redirects
+rewrite "^/press/summaries/([0-9]{4})/tables/congressional/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/congressional/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/presidential/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/presidential/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/party/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/party/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/pac/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/pac/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/ie/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/ie/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/ec/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/ec/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/cc/(.*).pdf" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/cc/$2.pdf redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/congressional/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/congressional/$2.xlsx redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/presidential/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/presidential/$2.xlsx redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/party/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/party/$2.xlsx redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/pac/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/pac/$2.xlsx redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/ie/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/ie/$2.xlsx redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/ec/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/ec/$2.xlsx redirect;
+rewrite "^/press/summaries/([0-9]{4})/tables/cc/(.*).xlsx" https://www.fec.gov/resources/campaign-finance-statistics/$1/tables/cc/$2.xlsx redirect;
+
 # /pubrec/ broader redirects
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;


### PR DESCRIPTION
Redirect campaign finance statistical summaries from the transition bucket to the content-s3 bucket.