### PR TITLE
Connect to eregs using internal route, add network policy to deploy script

### DIFF
--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -59,5 +59,6 @@ fi
 # Deploy app
 cf ${command} ${app} -f ${manifest}
 
-# Add network policy
+# Add network policies
 cf add-network-policy proxy cms
+cf add-network-policy proxy eregs

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -16,7 +16,7 @@ applications:
       PROXIES: |
         {
           "/": "http://fec-dev-cms.apps.internal:8080",
-          "/regulations": "https://fec-dev-eregs.app.cloud.gov"
+          "/regulations": "http://fec-dev-eregs.apps.internal:8080"
         }
       S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"
       S3_TRANSITION_URL: "https://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -18,7 +18,7 @@ applications:
       PROXIES: |
         {
           "/": "http://fec-prod-cms.apps.internal:8080",
-          "/regulations": "https://fec-prod-eregs.app.cloud.gov"
+          "/regulations": "http://fec-prod-eregs.apps.internal:8080"
         }
       S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"
       S3_TRANSITION_URL: "http://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -16,7 +16,7 @@ applications:
       PROXIES: |
         {
           "/": "http://fec-stage-cms.apps.internal:8080",
-          "/regulations": "https://fec-stage-eregs.app.cloud.gov"
+          "/regulations": "http://fec-stage-eregs.apps.internal:8080"
         }
       S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"
       S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-d3527d7d-0344-45b5-aab6-5a39d2aa409f.s3-us-gov-west-1.amazonaws.com"


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-accounts/issues/327

Part of https://github.com/fecgov/fec-accounts/issues/325

- Proxy connects to eregs with internal route, already uses bosh resolver
- add network policy to deploy script
![Screen Shot 2020-11-20 at 12.06.45 PM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/5b163142-7ed8-4b1a-91aa-bbc21a48f5c6)

## Reviewers

- At least two reviewers, please

## How to test

- Check out routes with `cf app eregs` and see the two routes for the eregs, internal and external
- Make a copy of this branch and name it and add `|| ${branch} == "<your_branch_name>" ]]` to this line: https://github.com/fecgov/fec-proxy/blob/ed7387c8ac1ee68bf42b02610c9b1fcb8560406a/bin/cf_deploy.sh#L14
So it reads:
```
if [[ ${branch} == "develop" || ${branch} == "<your_branch_name>" ]]; then
```
- Push up your branch
- Go to dev.fec.gov/regulations
- Make sure you can't access fec-dev-eregs.apps.internal
- Check that internal eregs route is listed in the `PROXIES` env var with `cf env proxy`