### PR TITLE
Fix redirects related to EEO and first ten years report

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -798,8 +798,8 @@ rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources
 rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/documents/commissioners_tips_2016_EO13892.pdf redirect;
 rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
 rewrite ^/pdf/eleccoll.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
-rewrite ^/pdf/firsttenyearsreport.pdf https://www.fec.gov/resources/about-fec/reports/firsttenyearsreport.pdf redirect;
-rewrite ^/pdf/firsttenyears.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyears.pdf redirect;
+rewrite ^/pdf/firsttenyearsreport.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
+rewrite ^/pdf/firsttenyears.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
 
 # pdf/nprm/ redirects
 rewrite ^/pdf/nprm/emilyslistrepeal/notice_2009-30.pdf https://www.fec.gov/resources/legal-resources/rulemakings/nprm/emilyslistrepeal/notice_2009-30.pdf redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -83,10 +83,17 @@ rewrite ^/disclosureie/ienational.do?candOffice=S https://www.fec.gov/data/indep
 rewrite ^/disclosurep/pnational.do https://www.fec.gov/data/candidates/president/presidential-map/ redirect;
 
 # eeo/ redirects
+rewrite ^/eeo/AfricanHistoryMonth.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
 rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/EEOCounselors.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/eeocounselors.htm https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/HispanicHeritageMonth.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
 rewrite ^/eeo/policy_statement.shtml https://www.fec.gov/about/equal-employment-opportunity/#policies-and-statements redirect;
 rewrite ^/eeo/documents/annual_no_fear_act.pdf https://www.fec.gov/resources/cms-content/documents/annual_no_fear_act.pdf redirect;
+rewrite ^/eeo/LegalAuth.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
 rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
+rewrite ^/eeo/MD-715Report.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
+rewrite ^/eeo/NoFear.shtml https://www.fec.gov/about/no-fear-act/ redirect;
 
 # elecfil/ redirects
 rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-cms/issues/4217

Fix redirects for the first ten years report: https://www.fec.gov/resources/cms-content/documents/firsttenyears.pdf

Add redirects for EEO .shtml pages. See comment: https://github.com/fecgov/fec-cms/issues/4217#issuecomment-736803809