### PR TITLE
BCRA file related redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -698,9 +698,12 @@ rewrite ^/pages/statefiling.shtml https://www.fec.gov/introduction-campaign-fina
 # pages/bcra/ redirects
 rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
 rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
+rewrite ^/pages/bcra/form_9_instructions.doc https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/fr67n230p71075_interim_reporting_policy.pdf https://www.fec.gov/resources/cms-content/documents/fr67n230p71075_interim_reporting_policy.pdf redirect;
 rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resources/ redirect;
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
+rewrite ^/pages/bcra/schedule_e_form_5_instructions.doc https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
 
 # pages/budget/ redirects
 rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
@@ -982,6 +985,10 @@ rewrite ^/members/?$ https://www.fec.gov/about/leadership-and-structure/commissi
 
 # MUR/ broader redirects
 rewrite ^/MUR/.* https://www.fec.gov/data/legal/search/enforcement/ redirect;
+
+# pages/bcra webform broader redirects
+rewrite ^/pages/bcra/(.*) https://www.fec.gov/resources/legal-resources/litigation/bcra/$1 redirect;
+rewrite ^/pages/bcra/bcra_webform(.*).pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
 
 # pdf/ broader redirects
 rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-cms/issues/4201

Redirects have been added according to instructions here: https://github.com/fecgov/fec-cms/issues/4201#issuecomment-738217582 

BCRA redirects documented in this [spreadsheet](https://docs.google.com/spreadsheets/d/1Jn5nC3fFku10RTCP5OAW6RiffjNBE4VwBubITQpCNK8/edit#gid=2012864385) 🔒 

**Changes include:**
- Redirect for Interim reporting policy document migrated from https://transition.fec.gov/pages/bcra/fr67n230p71075_interim_reporting_policy.pdf and uploaded to https://www.fec.gov/resources/cms-content/documents/fr67n230p71075_interim_reporting_policy.pdf
- Redirects for old BCRA forms redirected to forms page
- Redirects for all other BCRA files within `https://transition.fec.gov/pages/bcra/` has been migrated to `https://www.fec.gov/resources/legal-resources/litigation/bcra/`
