### PR TITLE
Adds redirects for transition court case alpha index pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -193,6 +193,39 @@ rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/help-candidate
 rewrite ^/law/policy.shtml https://www.fec.gov/legal-resources/policy-other-guidance/ redirect;
 rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
 
+# law/ alphabetical index court case pages redirects
+rewrite ^/law/litigation_CCA_Alpha.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_A.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_B.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_C.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_D.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_E.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_A.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_D.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_K.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_N.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_P.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_Q.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_FEC_T.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_F.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_G.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_H.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_I.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_J.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_K.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_L.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_M.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_N.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_O.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_P.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_R.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_S.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_T.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_U.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_V.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_W.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+rewrite ^/law/litigation_CCA_X.shtml https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/ redirect;
+
 # law/cfr/ redirects
 rewrite ^/law/cfr/cfr.shtml https://www.fec.gov/regulations redirect;
 rewrite ^/law/cfr/ej_citation.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/explanations-and-justifications-citation-index/ redirect;
@@ -497,7 +530,6 @@ rewrite ^/law/feca/feca.shtml https://www.fec.gov/legal-resources/legislation/ r
 rewrite ^/law/litigation/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 
 # law/litigation/ standalone court case redirects
-
 rewrite ^/law/litigation/beam.shtml https://www.fec.gov/legal-resources/court-cases/beam-v-hunter-formerly-beam-v-gonzales/ redirect;
 rewrite ^/law/litigation/berg.shtml https://www.fec.gov/legal-resources/court-cases/berg-v-barack-obama-et-al/ redirect;
 rewrite ^/law/litigation/beverly.shtml https://www.fec.gov/legal-resources/court-cases/beverly-v-fec/ redirect;


### PR DESCRIPTION
Redirects all of the alpha index pages to https://www.fec.gov/legal-resources/court-cases/court-case-alphabetical-index/