### PR TITLE
Remove cache-control header

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -56,7 +56,6 @@ http {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Script-Name "<%= path %>";
-        add_header Cache-Control "max-age=600";
       }
     <% end %>
 


### PR DESCRIPTION
Resolves #224 

Since `cache-control` is already handled at the application level in the CMS and Eregs, we do not need to control it in the proxy as well. This PR removes the additional `cache-control` header from the proxy.