### PR TITLE
Adds transition redirects for press pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -867,6 +867,9 @@ rewrite ^/portal/graphic_presentation.shtml https://www.fec.gov/data/ redirect;
 rewrite ^/portal/searchable.shtml https://www.fec.gov/data/ redirect;
 
 # press/ redirects
+rewrite ^/press/archived-campaign-finance-statistics.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics-pre-1989/ redirect;
+rewrite ^/press/campaign_finance_statistics.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics/ redirect;
+rewrite ^/press/campaign_finance_statistics-archive.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics-pre-1989/ redirect;
 rewrite ^/press/foia.shtml https://www.fec.gov/freedom-information-act/ redirect;
 rewrite ^/press/index.shtml https://www.fec.gov/press/ redirect;
 rewrite ^/press/news_releases.shtml https://www.fec.gov/updates/?update_type=press-release redirect;
@@ -878,9 +881,7 @@ rewrite ^/press/weekly_digests.shtml https://www.fec.gov/updates/?update_type=we
 rewrite ^/press/bkgnd/AllPublicFunds.xls https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.pdf redirect;
 rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://www.fec.gov/resources/cms-content/documents/enforcementstats1977to2021.pdf redirect;
 rewrite ^press/bkgnd/fund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-
-# press/campaign_finance_statistics.shtml redirects 
-rewrite ^/press/campaign_finance_statistics.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics/ redirect;
+rewrite ^/press/bkgnd/presidential_fund.shtml https://www.fec.gov/resources/cms-content/documents/Pres_Public_Funding.pdf redirect;
 
 # press/summaries/help redirects 
 rewrite ^/press/summaries/help/statistical_1975_2010.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics/formula-calculations-statistical-tables-election-cycles-1975-through-2010/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -186,6 +186,7 @@ rewrite ^/info/publications/30year.pdf https://www.fec.gov/resources/cms-content
 rewrite ^/law/draftaos.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
 rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;
 rewrite ^/law/legalconsideration.shtml https://www.fec.gov/legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
+rewrite ^/law/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/law/litigationmajor.shtml https://www.fec.gov/legal-resources/court-cases/#selected-court-cases redirect;
 rewrite ^/law/litigationrecent.shtml https://www.fec.gov/legal-resources/court-cases/#ongoing-litigation redirect;
 rewrite ^/law/lobbybundlingfaq.shtml https://www.fec.gov/help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;


### PR DESCRIPTION
Adding and organizing press statistical page redirects under proper bumper

Redirects for:
https://transition.fec.gov/press/bkgnd/history.shtml
https://transition.fec.gov/press/archived-campaign-finance-statistics.shtml
https://transition.fec.gov/press/campaign_finance_statistics-archive.shtml

Removes bumper for another statistics page (since it wasn't a subdirectory) and moves that redirect into press/ subdirectory.