### PR TITLE
Updates and organizes www redirects

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -1,257 +1,315 @@
 #Redirect rules for specific pages
 
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/foia/foiareport2015.pdf https://www.fec.gov/resources/cms-content/documents/foiareport2015.pdf redirect;
-rewrite ^/resources/foia/chieffoiareport2015.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2015.pdf redirect;
-rewrite ^/resources/updates/agendas/2011/mtgdoc_1145.pdf https://www.fec.gov/resources/cms-content/documents/mtgdoc_1145.pdf redirect;
-rewrite ^/resources/updates/agendas/2011/mtgdoc_1145a.pdf https://www.fec.gov/resources/cms-content/documents/mtgdoc_1145a.pdf redirect;
-rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
-rewrite ^/pdf/CoverLetter_20130725.pdf https://www.fec.gov/resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
-rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
-rewrite ^/pdf/1997_Enforcement_Manual.pdf https://www.fec.gov/resources/cms-content/documents/1997_enforcement_manual.pdf redirect;
-rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
-rewrite ^/pdf/2017-2018_rad_review_referral_procedures.pdf https://www.fec.gov/resources/cms-content/documents/2017-2018_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/RAD_Procedures_2015-16.pdf https://www.fec.gov/resources/cms-content/documents/2015-2016_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/RAD_Procedures_2013-14.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/RAD_Procedures.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
-rewrite ^/pdf/2016title26materialitythresholdsapproved09132016_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2016_audit_materiality_thresholds_title_26_presidential.pdf redirect;
-rewrite ^/pdf/2014AuthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_authorized.pdf redirect;
-rewrite ^/pdf/2014UnauthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf https://www.fec.gov/resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_unauthorized.pdf redirect;
-rewrite ^/pdf/2012title2authmaterialitythresholdsapprvd72313_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_authorized.pdf redirect;
-rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
-rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
-rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
-rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
-rewrite ^/pdf/audit_threshold_title26_2008.pdf https://www.fec.gov/resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
-rewrite ^/pages/brochures/audit_process.pdf https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;
-rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
-rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
-rewrite ^/rad/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml https://www.fec.gov/about/equal-employment-opportunity/limited-english-proficiency/ redirect;
-rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect; 
-rewrite ^/about/offices/EEO/EEO.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
-rewrite ^/about/offices/offices.shtml https://www.fec.gov/about/leadership-and-structure/fec-offices/ redirect; 
-rewrite ^/pages/brochures/partnership.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
-rewrite ^/pages/brochures/partnership_brochure.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
-rewrite ^/pages/brochures/partnership_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
-rewrite ^/pages/brochures/delegate_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
-rewrite ^/info/apptwo.htm https://www.fec.gov/resources/cms-content/documents/legrec1993.pdf redirect; 
-rewrite ^/info/appone.htm https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pdf/record/1996/index96_1.htm https://www.fec.gov/resources/cms-content/documents/index1996.pdf redirect;
-rewrite ^/pdf/record/1996/index96.htm https://www.fec.gov/resources/cms-content/documents/index1996.pdf redirect;
-rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
-rewrite ^/pages/record.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
-rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/pubrec/cfsdd/ https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
-rewrite ^/pages/statefiling.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
-rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
-rewrite ^/pages/brochures/TestingtheWaters.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
-rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/info/charts_cpe_2017.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice2017-02.pdf redirect;
-rewrite ^/info/charts_cpe_2016.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
-rewrite ^/info/charts_cpe_2015.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
-rewrite ^/info/charts_441ad_2014.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
-rewrite ^/info/charts_441ad_2013.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
-rewrite ^/info/charts_441ad_2012.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
-rewrite ^/info/charts_441ad_2011.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
-rewrite ^/info/charts_441ad_2010.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
-rewrite ^/info/charts_441ad.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+# Redirects for main directory
+rewrite ^/about.shtml /about/ redirect;
+rewrite ^/efiling /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/fosers/ http://sers.fec.gov/fosers/ redirect;
+rewrite ^/pindex.shtml /data/ redirect;
+rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
+rewrite ^/privacy.shtml /about/privacy-and-security-policy redirect;
+rewrite ^/support /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/working.shtml /about/#working-with-the-fec redirect;
+
+# Redirects for /about/offices/
+
+rewrite ^/about/offices/EEO/EEO.shtml /about/equal-employment-opportunity/ redirect;
+rewrite ^/about/offices/offices.shtml /about/leadership-and-structure/fec-offices/ redirect; 
+
+# Redircts for /af/
+rewrite ^/af/af_calc.shtml /legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
+
+# Redirects for /agenda/
+rewrite ^/agenda/agendas.shtml /updates/?update_type=meetings redirect;
+rewrite ^/agenda/meetings.shtml /updates/?update_type=meetings redirect;
+rewrite ^/agenda/2016/agendaaudithearing20161206.shtml /updates/december-6-2016-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2015/agenda_administrative_review_hearing20151102.shtml h/updates/november-2-2015-administrative-review-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2015/agendaaudithearing20150506.shtml /updates/rescheduled-to-wednesday-may-13-2015-at-1000-ammay-6-2015-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20141120.shtml /updates/november-20-2014-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20140612.shtml /updates/june-12-2014-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20140423.shtml /updates/april-23-2014audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2012/agendaaudithearing20120823.shtml /updates/august-23-2012-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2012/agendaaudithearing20120627.shtml /updates/june-27-2012-open-meeting/ redirect;
+rewrite ^/agenda/2010/oral_hearing20100120.shtml /updates/oral-hearing-postponed-open-meeting/ redirect;
+rewrite ^/agenda/2009/oral_hearing20091104.shtml /updates/november-4-2009-open-meeting/ redirect;
+
+
+# Redirects for /ans/
+rewrite ^/ans/answers.shtml /help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_general.shtml /introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/ans/answers_disclosure.shtml /introduction-campaign-finance/how-to-research-public-records/ redirect;
+rewrite ^/ans/answers_compliance.shtml /legal-resources/enforcement/ redirect;
+rewrite ^/ans/answers_pac.shtml /help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_party.shtml /help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_candidate.shtml /help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
+rewrite ^/ans/answers_filing.shtml /help-candidates-and-committees/ redirect;
+rewrite ^/ans/answers_public_funding.shtml /introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+
+# Redirects for /audio/
+rewrite ^/audio/images/audio.png https://transition.fec.gov/images/audio.png redirect;
+
+# Redirects for /auditsearch/
+rewrite ^/auditsearch/auditsearch.do /legal-resources/enforcement/audit-search/ redirect;
+
+# Redirects for /audits/
+rewrite ^/audits/audit_reports.shtml https://transition.fec.gov/audits/audit_reports.shtml redirect;
+rewrite ^/audits/audit_reports_auth.shtml https://transition.fec.gov/audits/audit_reports_auth.shtml redirect;
+rewrite ^/audits/audit_reports_pres.shtml https://transition.fec.gov/audits/audit_reports_pres.shtml redirect;
+rewrite ^/audits/audit_reports_unauth.shtml https://transition.fec.gov/audits/audit_reports_unauth.shtml redirect;
+rewrite ^/audits/understand_pres_audits.shtml /legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
+
+# Redirects for /calendar/
+rewrite ^/calendar/calendar.shtml /calendar/ redirect;
+
+# Redirects for /data/
+rewrite ^/data/DataCatalog.do /data/ redirect;
+rewrite ^/data/legal/advisory_opinions /data/legal/advisory-opinions/ redirect;
+rewrite ^/data/legal/search/advisory_opinions /data/legal/search/advisory-opinions/ redirect;
+
+# Redirects for /disclosure/
+rewrite ^/disclosure/pacSummary.do /data/browse-data/?tab=committees redirect;
+rewrite ^/disclosure/partySummary.do /data/browse-data/?tab=committees redirect;
+
+# Redirects for /directives/
+rewrite ^/directives/CommissionDirectives.shtml /about/leadership-and-structure/#commission-directives-and-policy redirect;
+
+# Redirects for /disclosurehs/
+rewrite ^/disclosurehs/hsnational.do /data/browse-data/?tab=candidates redirect;
+
+# Redirects for /disclosureie/ 
+rewrite ^/disclosureie/ienational.do /data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true redirect;
+rewrite ^/disclosureie/ienational.do?candOffice=S /data/independent-expenditures/?data_type=processed&is_notice=true&most_recent=true&candidate_office=S redirect;
+
+# Redirects for /disclosurep/
+rewrite ^/disclosurep/pnational.do /data/candidates/president/presidential-map/ redirect;
+
+# Redirects for /eeo/
+rewrite ^/eeo/eeo.shtml /about/equal-employment-opportunity/ redirect; 
+rewrite ^/eeo/LimitedEnglishProficiencyPlan.shtml /about/equal-employment-opportunity/limited-english-proficiency/ redirect;
+rewrite ^/eeo/NoFear.shtml /about/no-fear-act/ redirect;
+
+# Redirects for /elecfil/
+rewrite ^/elecfil/ef_overview.shtml /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/electron.shtml /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/online.shtml /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/elecfil/software.shtml /help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
+rewrite ^/elecfil/vendors.shtml /help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
+
+# Redirects for /em/
+rewrite ^/em/adr.shtml /legal-resources/enforcement/alternative-dispute-resolution/ redirect;
+rewrite ^/em/em.shtml /legal-resources/enforcement/ redirect;
+rewrite ^/em/enfpro/EnforcementProfile.shtml /legal-resources/enforcement/enforcement-profile/ redirect;
+rewrite ^/em/respondent_guide.pdf /resources/cms-content/documents/respondent_guide.pdf redirect;
+
+# Redirects for /fecig/
+rewrite ^/fecig/fecig.shtml /office-inspector-general/ redirect;
+
+# Redirects for /finance/
+rewrite ^/finance/disclosure/candcmte_info.shtml /data/ redirect;
+rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/finance/2012matching/2012matching.shtml redirect;
+rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
+rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml redirect;
+rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml redirect;
+
+# Redirects for /general/
+rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
+rewrite ^/general/FederalElections2016.shtml /introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/general/whatsnew.shtml /updates/ redirect;
+
+# Redirects for /images/
+rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcript_icon.png redirect;
+rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
+
+# Redirects for /info/
+rewrite ^/info/apptwo.htm /resources/cms-content/documents/legrec1993.pdf redirect; 
+rewrite ^/info/appone.htm /introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/info/charts_cpe_2017.shtml /resources/cms-content/documents/fedreg_notice2017-02.pdf redirect;
+rewrite ^/info/charts_cpe_2016.shtml /resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
+rewrite ^/info/charts_cpe_2015.shtml /resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
+rewrite ^/info/charts_441ad_2014.shtml /resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
+rewrite ^/info/charts_441ad_2013.shtml /resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
+rewrite ^/info/charts_441ad_2012.shtml /resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
+rewrite ^/info/charts_441ad_2011.shtml /resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
+rewrite ^/info/charts_441ad_2010.shtml /resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
+rewrite ^/info/charts_441ad.shtml /resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+rewrite ^/info/contriblimitschart1718.pdf /help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/elearning.shtml /help-candidates-and-committees/trainings/#e-learning-videos redirect;
+rewrite ^/info/ElectionDate/ /help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/espanol.shtml https://www.fec.gov/ redirect;
+rewrite ^/info/FECWebinars.shtml /help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
+rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
+rewrite ^/info/filing.shtml /help-candidates-and-committees/ redirect;
+rewrite ^/info/mission.shtml /about/mission-and-history/ redirect;
+rewrite ^/info/outreach.shtml /help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/publications.shtml /help-candidates-and-committees/guides/ redirect;
+rewrite ^/info/report_dates_2017.shtml /help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/roundtable_materials/workshopmaterials.shtml help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/TimelyTipsArchive.shtml /updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml /updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TipsforTreasurers.shtml /updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/toolkit.shtml /help-candidates-and-committees/ redirect;
+
+# Redirects for /info/guidance/
+rewrite ^/info/guidance/hlogabundling.shtml /help-candidates-and-committees/lobbyist-bundling-disclosure/ redirect;
+rewrite ^/info/guidance/recountreporting.shtml /help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
+
+# Redirects for /law/
+rewrite ^/law/law.shtml /legal-resources/ redirect;
+rewrite ^/law/cfr/cfr.shtml /regulations redirect;
+rewrite ^/law/draftaos.shtml /legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
+rewrite ^/law/feca/feca.shtml /legal-resources/legislation/ redirect;
+rewrite ^/law/legalconsideration.shtml /legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
+rewrite ^/law/litigation.shtml /legal-resources/court-cases/ redirect;
+rewrite ^/law/nonfederalfundraisingfaq2.shtml /help-candidates-and-committees/making-disbursements/fundraising-other-candidates-committees/ redirect;
+rewrite ^/law/policy.shtml /legal-resources/policy-other-guidance/ redirect;
+rewrite ^/law/procedural_materials.shtml /legal-resources/enforcement/procedural-materials/ redirect;
+rewrite ^/law/recentdevelopments.shtml /legal-resources/ redirect;
+
+# Redirects for /law/cfr/ej_compilation/
 rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2010/notice_2010-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2008/notice_2008-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2008-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
-rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/ans/answers.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/ans/answers_general.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/ans/answers_disclosure.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
-rewrite ^/ans/answers_compliance.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
-rewrite ^/ans/answers_pac.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/ans/answers_party.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/ans/answers_candidate.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
-rewrite ^/ans/answers_filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/ans/answers_public_funding.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/info/guidance/hlogabundling.shtml https://www.fec.gov/updates/lobbyist-bundling-disclosure-2019/ redirect;
-rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
-rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
-rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
-rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
-rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
-rewrite ^/portal/graphic_presentation.shtml http://classic.fec.gov/portal/graphic_presentation.shtml redirect;
-rewrite ^/disclosurep/pnational.do http://classic.fec.gov/disclosurep/pnational.do redirect;
-rewrite ^/disclosurehs/hsnational.do http://classic.fec.gov/disclosurehs/hsnational.do redirect;
-rewrite ^/disclosure/partySummary.do http://classic.fec.gov/disclosure/partySummary.do redirect;
-rewrite ^/disclosureie/ienational.do http://classic.fec.gov/disclosureie/ienational.do redirect;
-rewrite ^/disclosureie/ienational.do?candOffice=S http://classic.fec.gov/disclosureie/ienational.do?candOffice=S redirect;
-rewrite ^/disclosure/pacSummary.do http://classic.fec.gov/disclosure/pacSummary.do redirect;
-rewrite ^/portal/searchable.shtml http://classic.fec.gov/portal/searchable.shtml redirect;
-rewrite ^/data/legal/search/advisory_opinions /data/legal/search/advisory-opinions/ redirect;
-rewrite ^/data/legal/advisory_opinions /data/legal/advisory-opinions/ redirect;
-rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;
-rewrite ^/portal/download.shtml http://classic.fec.gov/portal/download.shtml redirect;
-rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;
-rewrite ^/agenda/meetings.shtml /updates/?update_type=meetings redirect;
-rewrite ^/agenda/agendas.shtml /updates/?update_type=meetings redirect;
-rewrite ^/agenda/2016/agendaaudithearing20161206.shtml https://www.fec.gov/updates/december-6-2016-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2015/agendaaudithearing20150506.shtml https://www.fec.gov/updates/rescheduled-to-wednesday-may-13-2015-at-1000-ammay-6-2015-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2014/agendaaudithearing20141120.shtml https://www.fec.gov/updates/november-20-2014-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2014/agendaaudithearing20140612.shtml https://www.fec.gov/updates/june-12-2014-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2014/agendaaudithearing20140423.shtml https://www.fec.gov/updates/april-23-2014audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2012/agendaaudithearing20120823.shtml https://www.fec.gov/updates/august-23-2012-audit-hearing-open-meeting/ redirect;
-rewrite ^/agenda/2012/agendaaudithearing20120627.shtml https://www.fec.gov/updates/june-27-2012-open-meeting/ redirect;
-rewrite ^/agenda/2010/oral_hearing20100120.shtml https://www.fec.gov/updates/oral-hearing-postponed-open-meeting/ redirect;
-rewrite ^/agenda/2009/oral_hearing20091104.shtml https://www.fec.gov/updates/november-4-2009-open-meeting/ redirect;
-rewrite ^/agenda/2015/agenda_administrative_review_hearing20151102.shtml https://www.fec.gov/updates/november-2-2015-administrative-review-hearing-open-meeting/ redirect;
-rewrite ^/calendar/calendar.shtml http://classic.fec.gov/calendar/calendar.shtml redirect;
-rewrite ^/law/legalconsideration.shtml https://transition.fec.gov/law/legalconsideration.shtml redirect;
-rewrite ^/em/em.shtml /legal-resources/enforcement/ redirect;
-rewrite ^/em/enfpro/EnforcementProfile.shtml https://transition.fec.gov/em/enfpro/EnforcementProfile.shtml redirect;
-rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/documents/respondent_guide.pdf redirect;
-rewrite ^/pages/brochures/admin_fines.shtml /legal-resources/enforcement/administrative-fines/ redirect;
-rewrite ^/af/af_calc.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
-rewrite ^/em/adr.shtml /legal-resources/enforcement/alternative-dispute-resolution/ redirect;
-rewrite ^/audits/audit_reports.shtml https://transition.fec.gov/audits/audit_reports.shtml redirect;
-rewrite ^/audits/audit_reports_auth.shtml https://transition.fec.gov/audits/audit_reports_auth.shtml redirect;
-rewrite ^/audits/audit_reports_unauth.shtml https://transition.fec.gov/audits/audit_reports_unauth.shtml redirect;
-rewrite ^/audits/audit_reports_pres.shtml https://transition.fec.gov/audits/audit_reports_pres.shtml redirect;
-rewrite ^/auditsearch/auditsearch.do http://classic.fec.gov/auditsearch/auditsearch.do redirect;
-rewrite ^/info/filing.shtml /help-candidates-and-committees/ redirect;
-rewrite ^/info/report_dates_2017.shtml https://transition.fec.gov/info/report_dates_2017.shtml redirect;
-rewrite ^/pdf/eleccoll.pdf https://transition.fec.gov/pdf/eleccoll.pdf redirect;
-rewrite ^/pdf/candgui.pdf /resources/cms-content/documents/candgui.pdf redirect;
-rewrite ^/pdf/partygui.pdf /resources/cms-content/documents/partygui.pdf redirect;
-rewrite ^/pdf/nongui.pdf /resources/cms-content/documents/nongui.pdf redirect;
-rewrite ^/elecfil/electron.shtml /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/efiling /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/support /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
-rewrite ^/info/filing.shtml /help-candidates-and-committees/ redirect;
-rewrite ^/info/ElectionDate/ /help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/publications.shtml /help-candidates-and-committees/guides/ redirect;
-rewrite ^/pages/fecrecord/fecrecord.shtml /updates/?update_type=fec-record redirect;
-rewrite ^/pages/record.shtml /updates/?update_type=fec-record redirect;
-rewrite ^/pages/bcra/bcra_update.shtml /legal-resources/legislation/ redirect;
-rewrite ^/pages/bcra/major_resources_bcra.shtml /legal-resources/ redirect;
-rewrite ^/pages/bcra/litigation.shtml /legal-resources/court-cases/ redirect;
-rewrite ^/pages/bcra/aos_bcra.shtml /data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
-rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml /legal-resources/regulations/ redirect;
-rewrite ^/info/outreach.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
-rewrite ^/info/TipsforTreasurers.shtml /updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/law/law.shtml /legal-resources/ redirect;
-rewrite ^/law/feca/feca.shtml /legal-resources/legislation/ redirect;
-rewrite ^/law/cfr/cfr.shtml /regulations redirect;
-rewrite ^/fosers/ http://sers.fec.gov/fosers/ redirect;
-rewrite ^/pages/bcra/bcra_update.shtml https://transition.fec.gov/pages/bcra/bcra_update.shtml redirect;
-rewrite ^/law/policy.shtml https://transition.fec.gov/law/policy.shtml redirect;
-rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
-rewrite ^/law/recentdevelopments.shtml https://www.fec.gov/legal-resources/ redirect;
-rewrite ^/pages/brochures/ao.shtml /data/legal/advisory-opinions/ redirect;
-rewrite ^/law/draftaos.shtml /legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
-rewrite ^/law/litigation.shtml https://transition.fec.gov/law/litigation.shtml redirect;
-rewrite ^/calendar/calendar.shtml http://classic.fec.gov/calendar/calendar.shtml redirect;
-rewrite ^/about.shtml /about/ redirect;
+
+# Redirects for /links_files/
+rewrite ^/links_files/Links.shtml /about/ redirect;
+
+# Redirects for /members/
 rewrite ^/members/?$ /about/leadership-and-structure/commissioners/ redirect;
-rewrite ^/info/mission.shtml /about/mission-and-history/ redirect;
-rewrite ^/about/offices/offices.shtml https://transition.fec.gov/about/offices/offices.shtml redirect;
-rewrite ^/pages/jobs/jobs.shtml /about/careers/ redirect;
-rewrite ^/eeo/eeo.shtml https://www.fec.gov/about/equal-employment-opportunity/ redirect;
-rewrite ^/working.shtml /about/#working-with-the-fec redirect;
-rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
-rewrite ^/open/index.shtml /open/ redirect;
-rewrite ^/press/index.shtml /press/ redirect;
-rewrite ^/press/news_releases.shtml /updates/?update_type=press-release redirect;
-rewrite ^/press/weekly_digests.shtml /updates/?update_type=weekly-digest redirect;
-rewrite ^/press/campaign_finance_statistics.shtml https://transition.fec.gov/press/campaign_finance_statistics.shtml redirect;
-rewrite ^/press/resources_for_reporters.shtml /press/resources-journalists/ redirect;
-rewrite ^/press/press_contacts.shtml /press/#contact redirect;
-rewrite ^/pages/contact.shtml /contact-us/ redirect;
-rewrite ^/directives/CommissionDirectives.shtml /about/leadership-and-structure/#commission-directives-and-policy redirect;
-rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
-rewrite ^/pages/procure/procure.shtml /about/reports-about-fec/procurement-and-contracting/ redirect;
-rewrite ^/pages/anreport.shtml /about/reports-about-fec/annual-and-anniversary-reports/ redirect;
-rewrite ^/privacy.shtml /about/privacy-and-security-policy redirect;
-rewrite ^/info/FECWebinars.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/roundtable_materials/workshopmaterials.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
-rewrite ^/press/foia.shtml /freedom-information-act/ redirect;
-rewrite ^/press/bkgnd/presidential_fund.shtml https://transition.fec.gov/press/bkgnd/presidential_fund.shtml redirect;
-rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://transition.fec.gov/press/bkgnd/EnforcementStatistics.shtml redirect;
-rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
-rewrite ^/general/FederalElections2016.shtml /introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/info/contriblimitschart1718.pdf https://transition.fec.gov/info/contriblimitschart1718.pdf redirect;
-rewrite ^/members/walther/walther.shtml /about/leadership-and-structure/steven-t-walther/ redirect;
-rewrite ^/members/walther/walther_bio.shtml /about/leadership-and-structure/steven-t-walther/ redirect;
-rewrite ^/members/walther/statements.shtml /about/leadership-and-structure/steven-t-walther/ redirect;
-rewrite ^/members/hunter/hunter.shtml /about/leadership-and-structure/caroline-c-hunter/ redirect;
-rewrite ^/members/hunter/hunter_bio.shtml /about/leadership-and-structure/caroline-c-hunter/ redirect;
-rewrite ^/members/hunter/statements.shtml /about/leadership-and-structure/caroline-c-hunter/ redirect;
 rewrite ^/members/goodman/goodman.shtml /about/leadership-and-structure/lee-e-goodman/ redirect;
 rewrite ^/members/goodman/goodman_bio.shtml /about/leadership-and-structure/lee-e-goodman/ redirect;
 rewrite ^/members/goodman/statements.shtml /about/leadership-and-structure/lee-e-goodman/ redirect;
-rewrite ^/members/weintraub/weintraub.shtml /about/leadership-and-structure/ellen-l-weintraub/ redirect;
-rewrite ^/members/weintraub/weintraubbio.shtml /about/leadership-and-structure/ellen-l-weintraub/ redirect;
-rewrite ^/members/weintraub/weintraub_speeches.shtml /about/leadership-and-structure/ellen-l-weintraub/ redirect;
+rewrite ^/members/hunter/hunter.shtml /about/leadership-and-structure/caroline-c-hunter/ redirect;
+rewrite ^/members/hunter/hunter_bio.shtml /about/leadership-and-structure/caroline-c-hunter/ redirect;
+rewrite ^/members/hunter/statements.shtml /about/leadership-and-structure/caroline-c-hunter/ redirect;
 rewrite ^/members/petersen/petersen.shtml /about/leadership-and-structure/mathew-s-petersen/ redirect;
 rewrite ^/members/petersen/petersen_bio.shtml /about/leadership-and-structure/mathew-s-petersen/ redirect;
 rewrite ^/members/petersen/statements.shtml /about/leadership-and-structure/mathew-s-petersen/ redirect;
-rewrite ^/general/whatsnew.shtml /updates/ redirect;
-rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
-rewrite ^/links_files/Links.shtml http://classic.fec.gov/links_files/Links.shtml redirect;
-rewrite ^/eeo/NoFear.shtml /about/no-fear-act/ redirect;
-rewrite ^/info/espanol.shtml https://www.fec.gov/ redirect;
-rewrite ^/finance/disclosure/candcmte_info.shtml /data redirect;
-rewrite ^/audio/images/audio.png https://transition.fec.gov/images/audio.png redirect;
-rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcript_icon.png redirect;
-rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
-rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
-rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
-rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
-rewrite ^/info/TimelyTipsArchive.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/info/guidance/recountreporting.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
-rewrite ^/law/nonfederalfundraisingfaq2.shtml https://www.fec.gov/updates/fundraising-federal-candidates-and-officeholders-other-candidates-and-committees-2017/ redirect;
-rewrite ^/elecfil/ef_overview.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/elecfil/online.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
-rewrite ^/elecfil/software.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
-rewrite ^/elecfil/vendors.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
-rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml redirect;
-rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml redirect;
-rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/finance/2012matching/2012matching.shtml redirect;
-rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
-rewrite ^/audits/understand_pres_audits.shtml https://www.fec.gov/legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
+rewrite ^/members/walther/walther.shtml /about/leadership-and-structure/steven-t-walther/ redirect;
+rewrite ^/members/walther/walther_bio.shtml /about/leadership-and-structure/steven-t-walther/ redirect;
+rewrite ^/members/walther/statements.shtml /about/leadership-and-structure/steven-t-walther/ redirect;
+rewrite ^/members/weintraub/weintraub.shtml /about/leadership-and-structure/ellen-l-weintraub/ redirect;
+rewrite ^/members/weintraub/weintraubbio.shtml /about/leadership-and-structure/ellen-l-weintraub/ redirect;
+rewrite ^/members/weintraub/weintraub_speeches.shtml /about/leadership-and-structure/ellen-l-weintraub/ redirect;
+
+# Redirects for /open/
+rewrite ^/open/index.shtml /open/ redirect;
+
+# Redirects for /pages/
+rewrite ^/pages/anreport.shtml /about/reports-about-fec/annual-and-anniversary-reports/ redirect;
+rewrite ^/pages/contact.shtml /contact-us/ redirect;
+rewrite ^/pages/record.shtml updates/record-archive-1975-2004/ redirect;
+rewrite ^/pages/statefiling.shtml /introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
+rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
+rewrite ^/pages/fecrecord/fecrecord.shtml /updates/?update_type=fec-record redirect;
+rewrite ^/pages/jobs/jobs.shtml /about/careers/ redirect;
+rewrite ^/pages/procure/procure.shtml /about/reports-about-fec/procurement-and-contracting/ redirect;
+
+# Redirects for /pages/bcra/
+rewrite ^/pages/bcra/aos_bcra.shtml /data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
+rewrite ^/pages/bcra/bcra_update.shtml /legal-resources/legislation/ redirect;
+rewrite ^/pages/bcra/litigation.shtml /legal-resources/court-cases/ redirect;
+rewrite ^/pages/bcra/major_resources_bcra.shtml /legal-resources/ redirect;
+rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml /legal-resources/regulations/ redirect;
+
+# Redirects for /pages/brochures/
+rewrite ^/pages/brochures/admin_fines.shtml /legal-resources/enforcement/administrative-fines/ redirect;
+rewrite ^/pages/brochures/ao.shtml /legal-resources/advisory-opinions-process/ redirect;
+rewrite ^/pages/brochures/audit_process.pdf /resources/cms-content/documents/audit_process.pdf redirect;
+rewrite ^/pages/brochures/delegate_brochure.pdf /help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
+rewrite ^/pages/brochures/ec-brochure.pdf /help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/electioneering.shtml /help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
+rewrite ^/pages/brochures/ie_brochure.pdf /help-candidates-and-committees/making-independent-expenditures/ redirect;
+rewrite ^/pages/brochures/indexp.shtml /help-candidates-and-committees/making-independent-expenditures/ redirect;
+rewrite ^/pages/brochures/internetcomm.shtml /introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/pages/brochures/jointfundraising_brochure.pdf /help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
+rewrite ^/pages/brochures/notices.shtml /help-candidates-and-committees/advertising-and-disclaimers/ redirect;
+rewrite ^/pages/brochures/partnership.shtml /help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
+rewrite ^/pages/brochures/partnership_brochure.shtml /help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
+rewrite ^/pages/brochures/partnership_brochure.pdf /help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2016.shtml /help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
+rewrite ^/pages/brochures/spec_notice_brochure.pdf /help-candidates-and-committees/advertising-and-disclaimers/ redirect;
+rewrite ^/pages/brochures/testing_waters.pdf /help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
+rewrite ^/pages/brochures/TestingtheWaters.shtml /help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
+
+# Redirects for /pdf/
+rewrite ^/pdf/2017-2018_rad_review_referral_procedures.pdf /resources/cms-content/documents/2017-2018_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/2016title26materialitythresholdsapproved09132016_redacted.pdf /resources/cms-content/documents/2016_audit_materiality_thresholds_title_26_presidential.pdf redirect;
+rewrite ^/pdf/2014AuthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf /resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_authorized.pdf redirect;
+rewrite ^/pdf/2014UnauthorizedMaterialityThresholds_Redacted_for_Public_Release.pdf /resources/cms-content/documents/2013-2014_audit_materiality_thresholds_title_52_unauthorized.pdf redirect;
+rewrite ^/pdf/2012title2authmaterialitythresholdsapprvd72313_redacted.pdf /resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_authorized.pdf redirect;
+rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf /resources/cms-content/documents/2011-2012_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
+rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf /resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
+rewrite ^/pdf/1997_Enforcement_Manual.pdf /resources/cms-content/documents/1997_enforcement_manual.pdf redirect;
+rewrite ^/pdf/Additional_Enforcement_Materials.pdf /resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
+rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf /resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
+rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf /resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
+rewrite ^/pdf/audit_threshold_title26_2008.pdf /resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
+rewrite ^/pdf/candgui.pdf /resources/cms-content/documents/candgui.pdf redirect;
+rewrite ^/pdf/colagui.pdf /resources/cms-content/documents/colagui.pdf redirect;
+rewrite ^/pdf/CoverLetter_20130725.pdf /resources/cms-content/documents/letter_to_Committee_on_House_Administration_July_25_2013.pdf redirect;
+rewrite ^/pdf/eleccoll.pdf /introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/#electoral-college redirect;
+rewrite ^/pdf/partygui.pdf /resources/cms-content/documents/partygui.pdf redirect;
+rewrite ^/pdf/nongui.pdf /resources/cms-content/documents/nongui.pdf redirect;
+rewrite ^/pdf/RAD_Procedures_2015-16.pdf /resources/cms-content/documents/2015-2016_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures_2013-14.pdf /resources/cms-content/documents/2013-2014_RAD_review_and_referral_procedures.pdf redirect;
+rewrite ^/pdf/RAD_Procedures.pdf /resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
+
+# Redirects for /pdf/forms/
+rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1party.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
+
+# Redirects for /pdf/record/
+rewrite ^/pdf/record/1996/index96_1.htm /resources/cms-content/documents/index1996.pdf redirect;
+rewrite ^/pdf/record/1996/index96.htm /resources/cms-content/documents/index1996.pdf redirect;
+
+# Redirects for /portal/
+rewrite ^/portal/download.shtml /data/browse-data/?tab=bulk-data redirect; 
+rewrite ^/portal/graphic_presentation.shtml /data/ redirect;
+rewrite ^/portal/searchable.shtml /data/ redirect;
+
+# Redirects for /press/
+rewrite ^/press/archived-campaign-finance-statistics.shtml /campaign-finance-data/campaign-finance-statistics-pre-1989/ redirect;
+rewrite ^/press/campaign_finance_statistics.shtml /campaign-finance-data/campaign-finance-statistics/ redirect;
+rewrite ^/press/campaign_finance_statistics-archive.shtml /campaign-finance-data/campaign-finance-statistics-pre-1989/ redirect;
+rewrite ^/press/foia.shtml /freedom-information-act/ redirect;
+rewrite ^/press/index.shtml /press/ redirect;
+rewrite ^/press/news_releases.shtml /updates/?update_type=press-release redirect;
+rewrite ^/press/press_contacts.shtml /press/#contact redirect;
+rewrite ^/press/resources_for_reporters.shtml /press/resources-journalists/ redirect;
+rewrite ^/press/weekly_digests.shtml /updates/?update_type=weekly-digest redirect;
+
+# Redirects for /press/bkgnd/
+rewrite ^/press/bkgnd/presidential_fund.shtml /resources/cms-content/documents/Pres_Public_Funding.pdf redirect;
+rewrite ^/press/bkgnd/EnforcementStatistics.shtml /legal-resources/enforcement/enforcement-profile/ redirect;
+
+# Redirects for /pubrec/cfsdd/
+rewrite ^/pubrec/cfsdd/ /introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
+rewrite ^/pubrec/cfsdd/cfsdd.shtml /introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
+rewrite ^/pubrec/cfsdd/cfsded_000.pdf /resources/cms-content/documents/cfsded.pdf redirect;
+
+# Redirects for /rad/
+rewrite ^/rad/documents/FECFileGettingStartedManual.pdf /resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 
 # Redirects for /resources/about-fec/
 rewrite ^/resources/about-fec/reports/20year.pdf https://www.fec.gov/resources/cms-content/documents/20year.pdf redirect;
@@ -260,11 +318,125 @@ rewrite ^/resources/about-fec/reports/firsttenyearsreport.pdf https://www.fec.go
 rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resources/cms-content/documents/cbr_app_d.pdf redirect;
 rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
 
+# Redirects for /resources/cms-content/documents/
+rewrite ^/resources/cms-content/documents/chieffoiareport12.pdf /resources/cms-content/documents/chieffoiareport12.pdf redirect;
+rewrite ^/resources/cms-content/documents/foiareport2012.pdf /resources/cms-content/documents/foiareport2012.pdf redirect;
+rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
+rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
+rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+
 # Redirects for /resources/foia/
-rewrite ^/resources/foia/chieffoiareport2016.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2016.pdf redirect;
-rewrite ^/resources/foia/chieffoiareport2017.pdf https://www.fec.gov/resources/cms-content/documents/chieffoiareport2017.pdf redirect;
+rewrite ^/resources/foia/brgoals.pdf /resources/cms-content/documents/brgoals.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2017.pdf /resources/cms-content/documents/chieffoiareport2017.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2016.pdf /resources/cms-content/documents/chieffoiareport2016.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2015.pdf /resources/cms-content/documents/chieffoiareport2015.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2014.pdf /resources/cms-content/documents/chieffoiareport2014.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport2013.pdf /resources/cms-content/documents/chieffoiareport2013.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport11.pdf /resources/cms-content/documents/chieffoiareport11.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport09.pdf /resources/cms-content/documents/chieffoiareport09.pdf redirect;
+rewrite ^/resources/foia/foiareport2015.pdf /resources/cms-content/documents/foiareport2015.pdf redirect;
+rewrite ^/resources/foia/foiareport2014.pdf /resources/cms-content/documents/foiareport2014.pdf redirect;
+rewrite ^/resources/foia/foiareport2011.pdf /resources/cms-content/documents/foiareport2011.pdf redirect;
+rewrite ^/resources/foia/foiareport2010.pdf /resources/cms-content/documents/foiareport2010.pdf redirect;
+rewrite ^/resources/foia/foiareport2009.pdf /resources/cms-content/documents/foiareport2009.pdf redirect;
+rewrite ^/resources/foia/foiareport2008.pdf /resources/cms-content/documents/foiareport2008.pdf redirect;
+rewrite ^/resources/foia/foiareport2007.pdf /resources/cms-content/documents/foiareport2007.pdf redirect;
+rewrite ^/resources/foia/foiareport2006.pdf /resources/cms-content/documents/foiareport2006.pdf redirect;
+
+# Redirects for /resources/updates/agendas/2011/
+rewrite ^/resources/updates/agendas/2011/mtgdoc_1145.pdf https://www.fec.gov/resources/cms-content/documents/mtgdoc_1145.pdf redirect;
+rewrite ^/resources/updates/agendas/2011/mtgdoc_1145a.pdf https://www.fec.gov/resources/cms-content/documents/mtgdoc_1145a.pdf redirect;
 
 # This section is for broader redirects
+rewrite ^/auditsearch/(.*) https://www.fec.gov/legal-resources/enforcement/audit-search/ redirect;
+rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
+rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
+rewrite ^/data/advanced/$ /data/browse-data/ redirect;
+rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;
+rewrite ^/finance/(.*) https://transition.fec.gov/finance/(.*) redirect;
+rewrite ^/MUR/(.*) https://www.fec.gov/data/legal/search/enforcement/ redirect;
+rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;
+rewrite ^/rad/(.*) https://transition.fec.gov/rad/$1 redirect;
+rewrite ^/sunshine/([0-9]+)/(.*).pdf /resources/updates/sunshine-notices/$1/$2.pdf redirect;
+
+#Broader redirects for /agenda/ and subdirectories
+rewrite ^/agenda/([0-9]+)/documents/(.*) /resources/updates/agendas/$1/$2 redirect;
+rewrite ^/agenda/([0-9]+)/(.*).pdf /resources/updates/agendas/$1/$2.pdf redirect;
+rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1.pdf redirect;
+rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1.pdf redirect;
+rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
+rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
+
+# Broader redirects for /disclosure/
+rewrite ^/disclosure/(.*) /data/ redirect;
+rewrite ^/disclosure_data/(.*) /data/ redirect;
+rewrite ^/disclosurehs/(.*) https://www.fec.gov/data/browse-data/?tab=candidates redirect;
+rewrite ^/disclosureie/(.*) https://www.fec.gov/data/independent-expenditures/?most_recent=true&data_type=processed&is_notice=true redirect;
+rewrite ^/disclosurep/(.*) https://www.fec.gov/data/candidates/president/ redirect;
+
+# Broader redirects for /fecig/
+rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
+rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
+
+# Broader redirects for /fecviewer/
+rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;
+rewrite ^/fecviewer/CommitteeDetailFilings.do /data/?search=$arg_candidateCommitteeId redirect;
+
+# Broader redirects for /info/ subdirectories
+rewrite ^/info/conference_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/conferences/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/downloads/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/documents(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/ElectionDate/(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/LegislativeRecommendations([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+rewrite ^/info/presentations/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/roundtable_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/roundtables/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+
+# Broader redirects for /law/
+rewrite ^/law/cfr/ej_compilation/(.*) https://transition.fec.gov/law/cfr/ej_compilation/$1 redirect;
+rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+
+# Broader redirects for /law/litigation/
+rewrite ^/law/litigation/(.*).pdf https://www.fec.gov/resources/legal-resources/litigation/$1.pdf redirect;
+rewrite ^/law/litigation/(.*) https://www.fec.gov/legal-resources/court-cases/ redirect;
+
+# Broader redirects for /legal-resources/
+rewrite ^/legal-resources/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
+rewrite ^/legal-resources/court-cases/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
+
+# Broader redirects for /members/
+rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;
+rewrite ^/members/(.*).doc /resources/about-fec/commissioners/$1.doc redirect;
+
+# Broader redirects for /pages/ subdirectories
+rewrite ^/pages/brochures/(.*) https://transition.fec.gov/pages/brochures/$1 redirect;
+rewrite ^/pages/report_notices/(.*) http://transition.fec.gov/pages/report_notices/$1 redirect;
+
+# Broader redirects for /pdf/
+rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
+rewrite ^/pdf/nprm/(.*) /resources/legal-resources/rulemakings/nprm/$1 redirect;
+rewrite ^/pdf/record/(.*).pdf /resources/record/$1.pdf redirect;
+
+# Broader redirects for /press/
+rewrite ^/press/press([0-9]+)/(.*) https://www.fec.gov/resources/news_releases/$1/$2 redirect;
+rewrite ^/press/press(.*) http://transition.fec.gov/press/press$1 redirect;
+rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
+
+# Broader redirects for /pubrec/ and subdirectories
+rewrite ^/pubrec/(.*) https://transition.fec.gov/pubrec/$1 redirect;
+rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2016/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -284,69 +456,9 @@ rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/e
 rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/info/presentations/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/downloads/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/documents(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/roundtable_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/roundtables/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/conference_materials/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/conferences/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/ElectionDate/(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/data/advanced/$ /data/browse-data/ redirect;
-rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/info/LegislativeRecommendations([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
-rewrite ^/fecviewer/CandidateCommitteeDetail.do /data/?search=$arg_candidateCommitteeId redirect;
-rewrite ^/fecviewer/CommitteeDetailFilings.do /data/?search=$arg_candidateCommitteeId redirect;
-rewrite ^/pdf/nprm/(.*) /resources/legal-resources/rulemakings/nprm/$1 redirect;
-rewrite ^/pages/brochures/(.*) https://transition.fec.gov/pages/brochures/$1 redirect;
-rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
-rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
-rewrite ^/pdf/record/(.*).pdf /resources/record/$1.pdf redirect;
-rewrite ^/legal-resources/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
-rewrite ^/legal-resources/court-cases/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
-rewrite ^/law/litigation/(.*).pdf https://www.fec.gov/resources/legal-resources/litigation/$1.pdf redirect;
-rewrite ^/law/litigation/(.*) https://www.fec.gov/legal-resources/court-cases/ redirect;
-rewrite "^/fecig/documents/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
-rewrite "^/fecig/(.*)" https://www.fec.gov/resources/cms-content/documents/$1;
-rewrite ^/fecletter/(.*) http://classic.fec.gov/fecletter/$1 redirect;
-rewrite ^/info/conferences/(.*) http://transition.fec.gov/info/conferences/$1 redirect;
-rewrite ^/info/conference_materials/(.*) http://transition.fec.gov/info/conference_materials/$1 redirect;
-rewrite ^/pages/report_notices/(.*) http://transition.fec.gov/pages/report_notices/$1 redirect;
-rewrite ^/press/press([0-9]+)/(.*) https://www.fec.gov/resources/news_releases/$1/$2 redirect;
-rewrite ^/press/press(.*) http://transition.fec.gov/press/press$1 redirect;
-rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
-rewrite ^/portal/(.*) http://classic.fec.gov/portal/$1 redirect;
-rewrite ^/disclosurep/(.*) http://classic.fec.gov/disclosurep/$1 redirect;
-rewrite ^/disclosurehs/(.*) http://classic.fec.gov/disclosurehs/$1 redirect;
-rewrite ^/disclosure/(.*) http://classic.fec.gov/disclosure/$1 redirect;
-rewrite ^/disclosureie/(.*) http://classic.fec.gov/disclosureie/$1 redirect;
-rewrite ^/MUR/(.*) http://classic.fec.gov/MUR/ redirect;
-rewrite ^/auditsearch/(.*) http://classic.fec.gov/auditsearch/$1 redirect;
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
-rewrite ^/law/cfr/ej_compilation/(.*) https://transition.fec.gov/law/cfr/ej_compilation/$1 redirect;
-rewrite ^/sunshine/([0-9]+)/(.*).pdf /resources/updates/sunshine-notices/$1/$2.pdf redirect;
-rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;
-rewrite ^/members/(.*).doc /resources/about-fec/commissioners/$1.doc redirect;
-rewrite ^/rad/(.*) https://transition.fec.gov/rad/$1 redirect;
-rewrite ^/pubrec/(.*) https://transition.fec.gov/pubrec/$1 redirect;
-rewrite ^/agenda/([0-9]+)/documents/(.*) /resources/updates/agendas/$1/$2 redirect;
-rewrite ^/agenda/([0-9]+)/(.*).pdf /resources/updates/agendas/$1/$2.pdf redirect;
-rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1.pdf redirect;
-rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agendas/2002/$1.pdf redirect;
-rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
-rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
-rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
-rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
-rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
 
 # Broader redirects for resources/about-fec/
 rewrite ^/resources/about-fec/reports/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
-
 
 # Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format.
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -435,7 +435,6 @@ rewrite ^/press/press(.*) http://transition.fec.gov/press/press$1 redirect;
 rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
 
 # Broader redirects for /pubrec/ and subdirectories
-rewrite ^/pubrec/(.*) https://transition.fec.gov/pubrec/$1 redirect;
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
@@ -456,6 +455,7 @@ rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/e
 rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/(.*) https://transition.fec.gov/pubrec/$1 redirect;
 
 # Broader redirects for resources/about-fec/
 rewrite ^/resources/about-fec/reports/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -319,8 +319,6 @@ rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resource
 rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
 
 # Redirects for /resources/cms-content/documents/
-rewrite ^/resources/cms-content/documents/chieffoiareport12.pdf /resources/cms-content/documents/chieffoiareport12.pdf redirect;
-rewrite ^/resources/cms-content/documents/foiareport2012.pdf /resources/cms-content/documents/foiareport2012.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
 rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
@@ -339,10 +337,12 @@ rewrite ^/resources/foia/chieffoiareport2016.pdf /resources/cms-content/document
 rewrite ^/resources/foia/chieffoiareport2015.pdf /resources/cms-content/documents/chieffoiareport2015.pdf redirect;
 rewrite ^/resources/foia/chieffoiareport2014.pdf /resources/cms-content/documents/chieffoiareport2014.pdf redirect;
 rewrite ^/resources/foia/chieffoiareport2013.pdf /resources/cms-content/documents/chieffoiareport2013.pdf redirect;
+rewrite ^/resources/foia/chieffoiareport12.pdf /resources/cms-content/documents/chieffoiareport12.pdf redirect;
 rewrite ^/resources/foia/chieffoiareport11.pdf /resources/cms-content/documents/chieffoiareport11.pdf redirect;
 rewrite ^/resources/foia/chieffoiareport09.pdf /resources/cms-content/documents/chieffoiareport09.pdf redirect;
 rewrite ^/resources/foia/foiareport2015.pdf /resources/cms-content/documents/foiareport2015.pdf redirect;
 rewrite ^/resources/foia/foiareport2014.pdf /resources/cms-content/documents/foiareport2014.pdf redirect;
+rewrite ^/resources/foia/foiareport2012.pdf /resources/cms-content/documents/foiareport2012.pdf redirect;
 rewrite ^/resources/foia/foiareport2011.pdf /resources/cms-content/documents/foiareport2011.pdf redirect;
 rewrite ^/resources/foia/foiareport2010.pdf /resources/cms-content/documents/foiareport2010.pdf redirect;
 rewrite ^/resources/foia/foiareport2009.pdf /resources/cms-content/documents/foiareport2009.pdf redirect;


### PR DESCRIPTION
- Adds redirects for some FOIA files (see redirect spreadsheet, accessibility tab) and https://github.com/fecgov/fec-cms/issues/4321
- Updates redirects that were pointing to the classic site or to retired transition pages (see redirect spreadsheet, PI 13 innovation tab). Ones for the classic site were updated to match what we are redirecting transition pages to.
- Organizes redirects alphabetically and adds bumpers for subdirectories

Note for @kathycarothers Please verify that the ones from the accessibility tab were added in correctly.
