### PR TITLE
Redirects for 14.1 Enforcement links

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -258,9 +258,14 @@ rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/docu
 
 # em/enfpro redirects
 rewrite ^/em/enfpro/complistatsfy05-08.pdf https://www.fec.gov/resources/cms-content/documents/complistatsfy05-08.pdf redirect;
+rewrite ^/em/enfpro/Enforcement_Matters_(Updated_2_20_2018).pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
+rewrite ^/em/enfpro/Enforcement_Matters_Updated_2_20_2018.pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 rewrite ^/em/enfpro/EnforcementProfile.shtml https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 rewrite ^/em/enfpro/enforcestatsfy09-10.pdf https://www.fec.gov/resources/cms-content/documents/enforcestatsfy09-10.pdf redirect;
+rewrite ^/em/enfpro/enforcestatsfy1975-2019.pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
+rewrite ^/em/enfpro/enforcestatsfy1975-2018.pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 rewrite ^/em/enfpro/enforcestatsfy03-08.pdf https://www.fec.gov/resources/cms-content/documents/enforcestatsfy03-08.pdf redirect;
+rewrite ^/em/enfpro/enforcestatsfy06-08.pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 rewrite ^/em/enfpro/enfpro2005.pdf https://www.fec.gov/documents/2553/enfpro2005.pdf redirect;
 
 # fecig/ redirects


### PR DESCRIPTION
Redirects for 14.1. These are the em/enfpro/ links we need to remove from the Inventory list.