### PR TITLE
Adds redirects for three open meeting pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -26,6 +26,7 @@ rewrite ^/agenda/agendas.shtml https://www.fec.gov/updates/?update_type=meetings
 rewrite ^/agenda/meetings.shtml https://www.fec.gov/updates/?update_type=meetings redirect;
 
 # agenda/2016/ redirects
+rewrite ^/agenda/2016/agenda20160128.shtml https://www.fec.gov/updates/february-11-2016-open-meeting/ redirect;
 rewrite ^/agenda/2016/agendaaudithearing20161206.shtml https://www.fec.gov/updates/december-6-2016-audit-hearing-open-meeting/ redirect;
 
 # agenda/2015/ redirects
@@ -38,10 +39,12 @@ rewrite ^/agenda/2014/agendaaudithearing20140612.shtml https://www.fec.gov/updat
 rewrite ^/agenda/2014/agendaaudithearing20140423.shtml https://www.fec.gov/updates/april-23-2014audit-hearing-open-meeting/ redirect;
 
 # agenda/2012/ redirects
+rewrite ^/agenda/2012/agenda20120712.shtml https://www.fec.gov/updates/july-12-2012-canceled-open-meeting/ redirect;
 rewrite ^/agenda/2012/agendaaudithearing20120823.shtml https://www.fec.gov/updates/august-23-2012-audit-hearing-open-meeting/ redirect;
 rewrite ^/agenda/2012/agendaaudithearing20120627.shtml https://www.fec.gov/updates/june-27-2012-open-meeting/ redirect;
 
 # agenda/2010/ redirects
+rewrite ^/agenda/2010/agenda20100615.shtml https://www.fec.gov/updates/june-16-2010-open-meeting/ redirect;
 rewrite ^/agenda/2010/oral_hearing20100120.shtml https://www.fec.gov/updates/oral-hearing-postponed-open-meeting/ redirect;
 
 # agenda/


### PR DESCRIPTION
Resolves #4447 by redirecting these three meeting pages:

/agenda/2010/agenda20100615.shtml to https://www.fec.gov/updates/june-16-2010-open-meeting/ 
/agenda/2012/agenda20120712.shtml to https://www.fec.gov/updates/july-12-2012-canceled-open-meeting/  
/agenda/2016/agenda20160128.shtml to https://www.fec.gov/updates/february-11-2016-open-meeting/  