### PR TITLE
Redirects for 14.2 to move off transition

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1128,7 +1128,7 @@ rewrite ^/elecfil/authorized_manual/(.*) https://efilingapps.fec.gov/fecfiledoc/
 rewrite ^/elecfil/formats/(.*) https://efilingapps.fec.gov/registration/softwarelogs.htm redirect;
 
 # em/enfpro broader redirects
-rewrite ^/em/enfpro/Enforcement_Matters_(.*) https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
+rewrite ^/em/enfpro/Enforcement_Matters_(.*).pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 
 # fecig/ broader redirects
 rewrite ^/fecig/documents/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -261,8 +261,6 @@ rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/docu
 
 # em/enfpro redirects
 rewrite ^/em/enfpro/complistatsfy05-08.pdf https://www.fec.gov/resources/cms-content/documents/complistatsfy05-08.pdf redirect;
-rewrite ^/em/enfpro/Enforcement_Matters_(Updated_2_20_2018).pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
-rewrite ^/em/enfpro/Enforcement_Matters_Updated_2_20_2018.pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 rewrite ^/em/enfpro/EnforcementProfile.shtml https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 rewrite ^/em/enfpro/enforcestatsfy09-10.pdf https://www.fec.gov/resources/cms-content/documents/enforcestatsfy09-10.pdf redirect;
 rewrite ^/em/enfpro/enforcestatsfy1975-2019.pdf https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
@@ -297,7 +295,7 @@ rewrite ^/info/contriblimits1112.pdf https://www.fec.gov/help-candidates-and-com
 rewrite ^/info/contriblimits0910.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/info/contriblimits0708.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/info/contriblimitschart1718.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
-rewrite ^/info/contriblimitschart1516.pdf  https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/contriblimitschart1516.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/info/contriblimitschart1314.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/info/efnprm.htm https://sers.fec.gov/fosers/showpdf.htm?docid=62698 redirect;
 rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
@@ -1128,6 +1126,9 @@ rewrite ^/eeo/(.*).pdf https://www.fec.gov/about/equal-employment-opportunity/ r
 # elecfil/ broader redirects
 rewrite ^/elecfil/authorized_manual/(.*) https://efilingapps.fec.gov/fecfiledoc/fecfiledoc.pdf redirect;
 rewrite ^/elecfil/formats/(.*) https://efilingapps.fec.gov/registration/softwarelogs.htm redirect;
+
+# em/enfpro broader redirects
+rewrite ^/em/enfpro/Enforcement_Matters_(.*) https://www.fec.gov/legal-resources/enforcement/enforcement-profile/ redirect;
 
 # fecig/ broader redirects
 rewrite ^/fecig/documents/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -292,7 +292,16 @@ rewrite ^/info/charts_441ad_2010.shtml https://www.fec.gov/resources/cms-content
 rewrite ^/info/charts_441ad.shtml https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
 rewrite ^/info/checkoff.htm https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#the-tax-checkoff redirect;
 rewrite ^/info/compliance.shtml /index.html redirect;
+rewrite ^/info/contrib.htm https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-limits/ redirect;
+rewrite ^/info/contriblimits1112.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/contriblimits0910.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/contriblimits0708.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/contriblimitschart1718.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/contriblimitschart1516.pdf  https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/contriblimitschart1314.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/info/efnprm.htm https://sers.fec.gov/fosers/showpdf.htm?docid=62698 redirect;
 rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
+rewrite ^/info/elecmas.htm https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
 rewrite ^/info/election_day_links.shtml https://www.fec.gov/introduction-campaign-finance/election-day-information/ redirect;
 rewrite ^/info/filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/info/FECWebinars.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;


### PR DESCRIPTION
I have added the redirects for contribution limits, efnprm, and elecmas.