### PR TITLE
Adds redirects for info/notices

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -316,12 +316,17 @@ rewrite ^/info/TimelyTipsArchive2006.shtml https://www.fec.gov/updates/?update_t
 rewrite ^/info/TipsforTreasurers.shtml https://www.fec.gov/updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/toolkit.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 
-# info/ElectionDate/ Compliance map redirect
-rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-
 # info/articles/ redirects
 rewrite ^/info/articles/debtretirement09.pdf https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;
 rewrite ^/info/articles/windingdown09.pdf https://www.fec.gov/help-candidates-and-committees/winding-down-candidate-campaign/ redirect;
+
+# info/ElectionDate/ Compliance map redirect
+rewrite ^/info/ElectionDate/ https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+
+# info/notices/redirects
+rewrite ^/info/notices/2005/notice_2005-05.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-05.pdf redirect;
+rewrite ^/info/notices/2005/notice_2005-07.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
+rewrite ^/info/notices/2006/alprim.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 
 # info/guidance/ redirects
 rewrite ^/info/guidance/debt_retirement.shtml https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/ redirect;


### PR DESCRIPTION
Resolves #fec-cms/issues/4520

Redirects two FR notices from 2005 to equivalent in CMS

Redirects an old stray prior notice to dates and deadlines. We'll want to archive this notice with other old prior notices we've archived.