### PR TITLE
Fix loading of large MUR PDF files

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -3,7 +3,7 @@ applications:
   - name: proxy
     instances: 1
     memory: 256M
-    disk_quota: 256M
+    disk_quota: 700M
     routes:
       - route: dev.fec.gov
     stack: cflinuxfs3

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -3,7 +3,7 @@ applications:
   - name: proxy
     instances: 4
     memory: 512M
-    disk_quota: 256M
+    disk_quota: 1G
     routes:
       - route: beta.fec.gov
       - route: transition.fec.gov

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -3,7 +3,7 @@ applications:
   - name: proxy
     instances: 1
     memory: 512M
-    disk_quota: 256M
+    disk_quota: 1G
     routes:
       - route: stage.fec.gov
     stack: cflinuxfs3


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-cms/issues/4538

The larger case files for MURs can be as much as 650MB. When the proxy attempts to load those files, there is an error for "(28: No space left on device) while reading upstream". Since we are using the proxy to serve up those files back from the S3, additional disk space is required.

### How to test
- Checkout this branch and perform a manual deploy to the dev environment 
- Attempt to view the once broken MUR file: https://dev.fec.gov/files/legal/murs/950.pdf and the file should now load, compared to production which is broken https://www.fec.gov/files/legal/murs/950.pdf