### PR TITLE
Fix all public funds transition redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1036,7 +1036,7 @@ rewrite ^/press/resources_for_reporters.shtml https://www.fec.gov/press/resource
 rewrite ^/press/weekly_digests.shtml https://www.fec.gov/updates/?update_type=weekly-digest redirect;
 
 # press/bkgnd/ redirects
-rewrite ^/press/bkgnd/AllPublicFunds.xls https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.pdf redirect;
+rewrite ^/press/bkgnd/AllPublicFunds.xls https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls redirect;
 rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://www.fec.gov/resources/cms-content/documents/enforcementstats1977to2021.pdf redirect;
 rewrite ^press/bkgnd/fund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/press/bkgnd/presidential_fund.shtml https://www.fec.gov/resources/cms-content/documents/Pres_Public_Funding.pdf redirect;


### PR DESCRIPTION
We needed to fix the all public funds redirect to point to the XLS file rather than the PDF file.