### PR TITLE
Updates joint fundraising redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -930,8 +930,8 @@ rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-an
 rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
-rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
+rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/help-candidates-and-committees/joint-fundraising-candidates-political-committees/ redirect;
+rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/joint-fundraising-candidates-political-committees/ redirect;
 rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
 rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers redirect;
 rewrite ^/pages/brochures/partner.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;


### PR DESCRIPTION
Updates two joint fundraising redirects to point to https://www.fec.gov/help-candidates-and-committees/joint-fundraising-candidates-political-committees/