### PR TITLE
Updates www redirects for joint fundraising

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -244,7 +244,8 @@ rewrite ^/pages/brochures/electioneering.shtml /help-candidates-and-committees/o
 rewrite ^/pages/brochures/ie_brochure.pdf /help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/indexp.shtml /help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/internetcomm.shtml /introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
-rewrite ^/pages/brochures/jointfundraising_brochure.pdf /help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
+rewrite ^/pages/brochures/jointfundraising.shtml /help-candidates-and-committees/joint-fundraising-candidates-political-committees/ redirect;
+rewrite ^/pages/brochures/jointfundraising_brochure.pdf /help-candidates-and-committees/joint-fundraising-candidates-political-committees/ redirect;
 rewrite ^/pages/brochures/notices.shtml /help-candidates-and-committees/advertising-and-disclaimers/ redirect;
 rewrite ^/pages/brochures/partnership.shtml /help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
 rewrite ^/pages/brochures/partnership_brochure.shtml /help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;


### PR DESCRIPTION
Adds one www redirect for old brochure on transition and updates another. Both redirects point to https://www.fec.gov/help-candidates-and-committees/joint-fundraising-candidates-political-committees/.