### PR TITLE
Adds redirect for Press Office PDF to XLS file

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -323,6 +323,7 @@ rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resource
 rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
 
 # Redirects for /resources/cms-content/documents/
+rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
 rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;


### PR DESCRIPTION
Redirects https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.pdf to https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls

Resolves #[4616](https://github.com/fecgov/fec-cms/issues/4616)
