### PR TITLE
redirect transition litigation documents to the new location on www

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1165,6 +1165,9 @@ rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treas
 rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 
+# law/litigation/ broader redirects
+rewrite ^/law/litigation/(.*).pdf https://www.fec.gov/resources/legal-resources/litigation/$1.pdf redirect;
+
 # law/cfr/ej_compilation/ broader redirects
 rewrite ^/law/cfr/ej_compilation/1976/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
 rewrite ^/law/cfr/ej_compilation/1975/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-cms/issues/4679

Create broader redirect for all litigation PDF files to go from transition to the new location on www