### PR TITLE
Add redirects for RAD FAQ transition pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -272,6 +272,9 @@ rewrite ^/em/enfpro/enfpro2005.pdf https://www.fec.gov/documents/2553/enfpro2005
 # fecig/ redirects
 rewrite ^/fecig/fecig.shtml https://www.fec.gov/office-inspector-general/ redirect;
 
+# finance/disclosure redirects
+rewrite ^/finance/disclosure/adv-search.shtml https://www.fec.gov/data/ redirect;
+
 # general/ redirects
 rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/general/library.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
@@ -942,6 +945,7 @@ rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaig
 rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
+rewrite ^/pages/brochures/rad_brochure.pdf https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
 rewrite ^/pages/brochures/sale_and_use_brochure.pdf https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
@@ -1072,7 +1076,20 @@ rewrite ^/pubrec/cfsdd/cfsdd.shtml https://www.fec.gov/introduction-campaign-fin
 rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/documents/cfsded.pdf redirect;
 
 # rad/ redirects
-rewrite ^/rad/index.shtml /rad/index.html redirect; 
+rewrite ^/rad/BitcoinFAQ.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/bitcoin-contributions/ redirect;
+rewrite ^/rad/candidates/FEC-ReportsAnalysisDivision-CandidateCommittees.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
+rewrite ^/rad/documents/best_practices_to_avoid_pitfalls_2018.pdf https://www.fec.gov/resources/cms-content/documents/best_practices_to_avoid_pitfalls_2018.pdf redirect;
+rewrite ^/rad/documents/RADProcessDocument3-16-16.pdf https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
+rewrite ^/rad/FEC-ReportsAnalysisDivision-Penalties.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/rad/FederalElectionCommission-RAD-ElectronicFilingPasswords.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/rad/FederalElectionCommission-RAD-RespondingtoRFAIs.shtml https://www.fec.gov/help-candidates-and-committees/request-additional-information/ redirect;
+rewrite ^/rad/index.shtml /rad/index.html redirect;
+rewrite ^/rad/index.html https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/rad/JointFundraisingCommittees.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees redirect;
+rewrite ^/rad/other_filers/FederalElectionCommission-RAD-OtherFilers.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=other-filers redirect;
+rewrite ^/rad/parties/FederalElectionCommission-RAD-Parties.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=political-party-committees redirect;
+rewrite ^/rad/pacs/FederalElectionCommission-RAD-PACs.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=political-action-committees redirect;
+rewrite ^/rad/rad_process/FEC-ReportsAnalysisDivision-RADProcesses.shtml https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
 
 # rad/candidates/documents/ redirects
 rewrite ^/rad/candidates/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
@@ -1269,6 +1286,9 @@ rewrite ^/pubrec/pacronyms/(.*) https://www.fec.gov/introduction-campaign-financ
 
 # sunshine/ broader redirects
 rewrite ^/sunshine/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/sunshine-notices/$1/$2.pdf redirect;
+
+# /rad/ broader redirects
+rewrite ^/rad/(.*) https://www.fec.gov/help-candidates-and-committees/ redirect;
 
 # Captures all dates of format agenda/YYYY/agendaYYYYMMDD
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})01([0-9]{2}).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1078,14 +1078,12 @@ rewrite ^/pubrec/cfsdd/cfsded_000.pdf https://www.fec.gov/resources/cms-content/
 # rad/ redirects
 rewrite ^/rad/BitcoinFAQ.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/bitcoin-contributions/ redirect;
 rewrite ^/rad/candidates/FEC-ReportsAnalysisDivision-CandidateCommittees.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
-rewrite ^/rad/documents/best_practices_to_avoid_pitfalls_2018.pdf https://www.fec.gov/resources/cms-content/documents/best_practices_to_avoid_pitfalls_2018.pdf redirect;
-rewrite ^/rad/documents/RADProcessDocument3-16-16.pdf https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
 rewrite ^/rad/FEC-ReportsAnalysisDivision-Penalties.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
 rewrite ^/rad/FederalElectionCommission-RAD-ElectronicFilingPasswords.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/rad/FederalElectionCommission-RAD-RespondingtoRFAIs.shtml https://www.fec.gov/help-candidates-and-committees/request-additional-information/ redirect;
-rewrite ^/rad/index.shtml /rad/index.html redirect;
+rewrite ^/rad/index.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/rad/index.html https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/rad/JointFundraisingCommittees.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees redirect;
+rewrite ^/rad/JointFundraisingCommittees.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/joint-fundraising-candidates-political-committees/ redirect;
 rewrite ^/rad/other_filers/FederalElectionCommission-RAD-OtherFilers.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=other-filers redirect;
 rewrite ^/rad/parties/FederalElectionCommission-RAD-Parties.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=political-party-committees redirect;
 rewrite ^/rad/pacs/FederalElectionCommission-RAD-PACs.shtml https://www.fec.gov/help-candidates-and-committees/guides/?tab=political-action-committees redirect;
@@ -1096,6 +1094,8 @@ rewrite ^/rad/candidates/documents/FECFileGettingStartedManual.pdf https://www.f
 
 # rad/documents/ redirects
 rewrite ^/rad/documents/FECFileGettingStartedManual.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
+rewrite ^/rad/documents/best_practices_to_avoid_pitfalls_2018.pdf https://www.fec.gov/resources/cms-content/documents/best_practices_to_avoid_pitfalls_2018.pdf redirect;
+rewrite ^/rad/documents/RADProcessDocument3-16-16.pdf https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
 
 # support/ redirects
 rewrite ^/support/faq_filing.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;


### PR DESCRIPTION
### Summary
Redirects RAD FAQ pages and documents linked on the RAD FAQ transition page.
Resolves [cms #4628](https://github.com/fecgov/fec-cms/issues/4628)