### PR TITLE
Create redirects-e-regs.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -36,6 +36,7 @@ http {
 
     client_max_body_size 100M;
     include redirects-www.conf;
+    include redirects-e-regs.conf;
 
     # Redirect for bulk-downloads bucket (needed this redirect here in order to access environment variable)
     rewrite ^/files/bulk-downloads/(.*)$ {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/bulk-downloads/$1 redirect;

--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -1,6 +1,6 @@
 # Redirect rules for specific pages
 
 # e-regs redirects 
-rewrite ^/111-24/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
-rewrite ^/111-43/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
-rewrite ^/111-44/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
+rewrite ^/regulations/111-24/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
+rewrite ^/regulations/111-43/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
+rewrite ^/regulations/111-44/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;

--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -1,6 +1,6 @@
 # Redirect rules for specific pages
 
 # e-regs redirects 
-rewrite ^/regulations/111-24/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_124&rgn=div8 redirect;
-rewrite ^/regulations/111-43/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_143&rgn=div8 redirect;
-rewrite ^/regulations/111-44/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_144&rgn=div8 redirect;
+rewrite ^/regulations/111-24/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
+rewrite ^/regulations/111-43/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
+rewrite ^/regulations/111-44/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;

--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -1,6 +1,6 @@
 # Redirect rules for specific pages
 
 # e-regs redirects 
-rewrite ^/regulations/111-24/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
-rewrite ^/regulations/111-43/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
-rewrite ^/regulations/111-44/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
+rewrite ^/regulations/111-24/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_124&rgn=div8 redirect;
+rewrite ^/regulations/111-43/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_143&rgn=div8 redirect;
+rewrite ^/regulations/111-44/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_144&rgn=div8 redirect;

--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -1,0 +1,6 @@
+# Redirect rules for specific pages
+
+# e-regs redirects 
+rewrite ^/111-24/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
+rewrite ^/111-43/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;
+rewrite ^/111-44/2020-annual-111 https://sers.fec.gov/fosers/showpdf.htm?docid=412715 redirect;


### PR DESCRIPTION
These three pages for regs (11 CFR 111.24, 111.43 and 111.44):
https://www.fec.gov/regulations/111-24/2020-annual-111
https://www.fec.gov/regulations/111-43/2020-annual-111
https://www.fec.gov/regulations/111-44/2020-annual-111

~will need to redirect to their ecfr pages:
https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_124&rgn=div8
https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_143&rgn=div8
https://www.ecfr.gov/cgi-bin/text-idx?SID=6f2b90c7c55a428fa3aaa938d6cd54c1&mc=true&node=se11.1.111_144&rgn=div8~

Redirecting to shorter URLs after checking with @PaulClark2 

will need to redirect to their ecfr pages:
https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124
https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143
https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144