### PR TITLE
Adds www redirects for some PDF files

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -159,6 +159,11 @@ rewrite ^/info/guidance/recountreporting.shtml /help-candidates-and-committees/c
 # Redirects for /law/
 rewrite ^/law/law.shtml /legal-resources/ redirect;
 rewrite ^/law/cfr/cfr.shtml /regulations redirect;
+rewrite ^/law/cfr/cfr_2009.pdf https://www.govinfo.gov/content/pkg/CFR-2009-title11-vol1/pdf/CFR-2009-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/cfr_2008.pdf https://www.govinfo.gov/content/pkg/CFR-2008-title11-vol1/pdf/CFR-2008-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/2014cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2014-title11-vol1/pdf/CFR-2014-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/11cfr2015.pdf https://www.govinfo.gov/content/pkg/CFR-2015-title11-vol1/pdf/CFR-2015-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/11_cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2010-title11-vol1/pdf/CFR-2010-title11-vol1.pdf redirect;
 rewrite ^/law/draftaos.shtml /legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
 rewrite ^/law/feca/feca.shtml /legal-resources/legislation/ redirect;
 rewrite ^/law/legalconsideration.shtml /legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
@@ -324,6 +329,7 @@ rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf http
 
 # Redirects for /resources/cms-content/documents/
 rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls redirect;
+rewrite ^/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justificiation.pdf https://www.fec.gov/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justification.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
 rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;


### PR DESCRIPTION
Adding www redirects for various 11 CFR PDFs and a misspelled budget PDF.

Redirects: 
/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justificiation.pdf to https://www.fec.gov/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justification.pdf redirect;

/law/cfr/various PDF files to the Federal Register notices on Gov Info

Resolves #https://github.com/fecgov/fec-cms/issues/4760