### PR TITLE
Adds www redirects (innovation)

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -165,6 +165,8 @@ rewrite ^/law/cfr/cfr_2008.pdf https://www.govinfo.gov/content/pkg/CFR-2008-titl
 rewrite ^/law/cfr/2014cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2014-title11-vol1/pdf/CFR-2014-title11-vol1.pdf redirect;
 rewrite ^/law/cfr/11cfr2015.pdf https://www.govinfo.gov/content/pkg/CFR-2015-title11-vol1/pdf/CFR-2015-title11-vol1.pdf redirect;
 rewrite ^/law/cfr/11_cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2010-title11-vol1/pdf/CFR-2010-title11-vol1.pdf redirect;
+rewrite ^/law/ej_compilation/2004/2004-05_Admin_Fines_Extension.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=36188 redirect;
+rewrite ^/law/ej_compilation/2001/2001-18_Admin_Fines_Extension.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=7419 redirect;
 rewrite ^/law/draftaos.shtml /legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
 rewrite ^/law/feca/feca.shtml /legal-resources/legislation/ redirect;
 rewrite ^/law/legalconsideration.shtml /legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
@@ -198,6 +200,7 @@ rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/reso
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
+
 
 # Redirects for /links_files/
 rewrite ^/links_files/Links.shtml /about/ redirect;
@@ -329,9 +332,11 @@ rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resource
 rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
 
 # Redirects for /resources/cms-content/documents/
-rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls redirect;
+rewrite ^/resources/about-fec/reports/budget/fy2015/FY2015-SummaryOfPerformanceAndFinancialInformation.pdf https://www.fec.gov/resources/cms-content/documents/FY2015-SummaryOfPerformanceAndFinancialInformation.pdf redirect;
 rewrite ^/resources/about-fec/reports/budget/fy2016/FY2016_AFR.pdf https://www.fec.gov/resources/cms-content/documents/FY2016_AFR.pdf redirect;
 rewrite ^/resources/about-fec/reports/budget/fy2017/fy_2017_Congressional_budget.pdf https://www.fec.gov/resources/cms-content/documents/fy_2017_Congressional_budget.pdf redirect;
+rewrite ^/resources/about-fec/reports/ITStrategicPlanFY2016-2020.pdf https://www.fec.gov/resources/cms-content/documents/ITStrategicPlanFY2016-2020.pdf redirect;
+rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls redirect;
 rewrite ^/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justificiation.pdf https://www.fec.gov/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justification.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-cms/issues/4852

Resolves https://github.com/fecgov/fec-cms/issues/4808

Redirects two old E&Js that didn't have a working www redirect.

Redirects two PDFS replaced for accessibility reasons.

Fixed some alphabetizing issues.

See Innovation tab of the [Redirects spreadsheet](https://docs.google.com/spreadsheets/d/1vzN-wZlS8K8ZyfExSV3hwXDenDEN9KyyAUJFTI6OjKU/edit#gid=888923420)