### PR TITLE
Fixes broader redirect for /finance

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -386,7 +386,7 @@ rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
 rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
 rewrite ^/data/advanced/$ /data/browse-data/ redirect;
 rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;
-rewrite ^/finance/(.*) https://transition.fec.gov/finance/(.*) redirect;
+rewrite ^/finance/(.*) https://transition.fec.gov/finance/$1 redirect;
 rewrite ^/MUR/(.*) https://www.fec.gov/data/legal/search/enforcement/ redirect;
 rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;
 rewrite ^/rad/(.*) https://transition.fec.gov/rad/$1 redirect;


### PR DESCRIPTION
As identified to fix the one wonky transition redirect from 16.2

/finance/disclosure/metadata/metadataforcandidatesummary.shtml should redirect to https://www.fec.gov/campaign-finance-data/candidate-summary-file-description/  (To make this work, we needed to fix this broader redirect in www).