### PR TITLE
Adds redirects for old hearing files

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -891,6 +891,7 @@ rewrite ^/law/policy/notice_2006-11.pdf https://www.fec.gov/resources/cms-conten
 rewrite ^/law/policy/disbursement_purpose.pdf https://www.fec.gov/resources/cms-content/documents/disbursement_purpose.pdf redirect;
 rewrite ^/law/policy/2004/notice2004-03.pdf https://www.fec.gov/resources/cms-content/documents/notice_2004-3.pdf redirect;
 rewrite ^/law/policy/2004/notice2004-20.pdf https://www.fec.gov/resources/cms-content/documents/notice2004-20.pdf redirect;
+rewrite ^/law/policy/bestefforts/comments.pdf https://www.fec.gov/legal-resources/policy-other-guidance/ redirect;
 rewrite ^/law/policy/enforcement_disclosure/perkins_coie.pdf https://www.fec.gov/resources/cms-content/documents/perkins_coie.pdf redirect;
 rewrite ^/law/policy/enforcement_disclosure/doj.pdf https://www.fec.gov/resources/cms-content/documents/doj.pdf redirect;
 rewrite ^/law/policy/formsrevisions2016/oconnor-formscomment.pdf https://www.fec.gov/resources/cms-content/documents/oconnor-formscomment.pdf redirect;
@@ -898,20 +899,29 @@ rewrite ^/law/policy/iedisseminationdate/seiucomment.pdf https://www.fec.gov/res
 rewrite ^/law/policy/iedisseminationdate/pomeranzcomment.pdf https://www.fec.gov/resources/cms-content/documents/pomeranzcomment.pdf redirect;
 
 # law/policy/embezzle/ redirects 
+rewrite ^/law/policy/embezzle/embezzlepolicy.pdf https://www.fec.gov/resources/cms-content/documents/embezzlementpolicy.pdf redirect;
 rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
 
 # law/policy/enforcement/ redirects
+rewrite ^/law/policy/enforcement/fec2008-13.pdf https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf redirect;
 rewrite ^/law/policy/enforcement/notice_2008-13.pdf https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf redirect;
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
 rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy/comments-received-enforcement-process-2013/ redirect;
 rewrite ^/law/policy/enforcement/2013/progressivesunited2.pdf https://www.fec.gov/resources/legal-resources/enforcement/policy/progressivesunited2.pdf redirect;
+rewrite ^/law/policy/enforcement/hearing/notice2013-01.pdf https://www.fec.gov/resources/cms-content/documents/notice2013-01.pdf redirect;
+
+# law/policy/enforcement/2009/ redirects
+rewrite ^/law/policy/enforcement/2009/011409hearingschedule.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
 rewrite ^/law/policy/enforcement/2009/01141509hearingtranscript.pdf https://www.fec.gov/resources/cms-content/documents/01141509hearingtranscript.pdf redirect;
-rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
+rewrite ^/law/policy/enforcement/2009/abareport82.pdf https://www.fec.gov/resources/cms-content/documents/abareport82.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/ao05-09.pdf https://www.fec.gov/resources/cms-content/documents/ao05-09.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/audits.pdf https://www.fec.gov/resources/cms-content/documents/audits.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/completerecord.pdf https://www.fec.gov/resources/cms-content/documents/completerecord.pdf redirect;
 rewrite ^/law/policy/enforcement/2009/hearingrecord.pdf https://www.fec.gov/resources/cms-content/documents/hearingrecord.pdf redirect;
 rewrite ^/law/policy/enforcement/2009/notice_2009-02.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-02.pdf redirect;
 rewrite ^/law/policy/enforcement/2009/recommendationsummary.pdf https://www.fec.gov/resources/cms-content/documents/recommendations_summary.pdf redirect;
 rewrite ^/law/policy/enforcement/2009/witnesses.pdf https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
-rewrite ^/law/policy/enforcement/hearing/notice2013-01.pdf https://www.fec.gov/resources/cms-content/documents/notice2013-01.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
 
 # law/policy/guidance/ redirects
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
@@ -961,6 +971,7 @@ rewrite ^/law/policy/purposeofdisbursement/comment_crp.pdf https://www.fec.gov/r
 rewrite ^/law/policy/suasponte/comm2.pdf https://www.fec.gov/resources/cms-content/documents/suasponte_comm2.pdf redirect;
 
 # Main directory redirects
+rewrite ^/elections.htm https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/elections.html https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pindex.shtml https://www.fec.gov/data/ redirect;
 rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
@@ -1015,7 +1026,7 @@ rewrite ^/pages/brochures/delegate_brochure.pdf https://www.fec.gov/help-candida
 rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
-rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
+rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/help-candidates-and-committees/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;


### PR DESCRIPTION
Redirects old hearing files found in transition inventory meeting, updates foreign national brochure redirect and adds election page redirect.

See 16.6 tab and inventory tab (line 171) of redirects spreadsheet for details.

Question for @patphongs - can we redirect http://efilingapps.fec.gov/fecfiledoc/module_8_2_3.html via this repo? Or is that done elsewhere?