### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Add partial redirect for civil penalties regulations

### DIFF
--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -7,3 +7,6 @@ rewrite ^/regulations/111-44/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-i
 rewrite ^/regulations/111-24/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
 rewrite ^/regulations/111-43/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
 rewrite ^/regulations/111-44/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;
+rewrite ^/regulations/partial/111-24/2021-annual-111 https://transition.fec.gov/regulations/page-ref-111-24.html redirect;
+rewrite ^/regulations/partial/111-43/2021-annual-111 https://transition.fec.gov/regulations/page-ref-111-43.html redirect;
+rewrite ^/regulations/partial/111-44/2021-annual-111 https://transition.fec.gov/regulations/page-ref-111-44.html redirect;


### PR DESCRIPTION
Redirect partial of civil penalties regs.

How to test:
- Go to https://dev.fec.gov/regulations/111
- Navigate to the corresponding redirected sections: 111.24, 111.43, and 111.44