### PR TITLE
Fixes policy page redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -900,13 +900,14 @@ rewrite ^/law/policy/iedisseminationdate/pomeranzcomment.pdf https://www.fec.gov
 
 # law/policy/embezzle/ redirects 
 rewrite ^/law/policy/embezzle/embezzlepolicy.pdf https://www.fec.gov/resources/cms-content/documents/embezzlementpolicy.pdf redirect;
-rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
+rewrite ^/law/policy/embezzle/embezzlementpolicycomments.shtml https://www.fec.gov/legal-resources/policy-other-guidance/comments-received-proposed-enforcement-policy-reporting-errors-caused-embezzlement-committee-funds-2006/ redirect;
 
 # law/policy/enforcement/ redirects
 rewrite ^/law/policy/enforcement/fec2008-13.pdf https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf redirect;
 rewrite ^/law/policy/enforcement/notice_2008-13.pdf https://www.fec.gov/resources/cms-content/documents/notice_2008-13.pdf redirect;
 rewrite ^/law/policy/enforcement/publichearing011409.shtml https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
-rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy/comments-received-enforcement-process-2013/ redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy-other-guidance/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
+rewrite ^/law/policy/enforcement/2013/2013commentsreceived.shtml https://www.fec.gov/legal-resources/policy-other-guidance/comments-received-enforcement-process-2013/ redirect;
 rewrite ^/law/policy/enforcement/2013/progressivesunited2.pdf https://www.fec.gov/resources/legal-resources/enforcement/policy/progressivesunited2.pdf redirect;
 rewrite ^/law/policy/enforcement/hearing/notice2013-01.pdf https://www.fec.gov/resources/cms-content/documents/notice2013-01.pdf redirect;
 
@@ -1027,6 +1028,7 @@ rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-an
 rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
 rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/help-candidates-and-committees/foreign-nationals/ redirect;
+rewrite ^/pages/brochures/foreign1.shtml https://www.fec.gov/help-candidates-and-committees/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
@@ -1062,7 +1064,7 @@ rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-arc
 rewrite ^/pages/hearings/hearingtranscript09-17-09.pdf https://www.fec.gov/resources/cms-content/documents/hearingtranscript09-17-09.pdf redirect;
 rewrite ^/pages/hearings/hearing_transcript20090825.pdf https://www.fec.gov/resources/cms-content/documents/hearing_transcript20090825.pdf redirect;
 rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
-rewrite ^/pages/hearings/internethearingcomments.shtml https://www.fec.gov/legal-resources/policy/website-internet-communications-improvement-initiative-comments/ redirect;
+rewrite ^/pages/hearings/internethearingcomments.shtml https://www.fec.gov/legal-resources/policy-other-guidance/website-internet-communications-improvement-initiative-comments/ redirect;
 rewrite ^/pages/hearings/opensession20091105.pdf https://www.fec.gov/resources/cms-content/documents/opensession20091105.pdf redirect;
 rewrite ^/pages/hearings/statusofwebsiteinitiative-bluedraftrev.pdf https://www.fec.gov/resources/updates/agendas/2009/mtgdoc0974.pdf redirect;
 


### PR DESCRIPTION
Fixes three policy page redirects, adds a fourth and adds a redirect for an outdated Spanish brochure.

See 17.2 tab of [redirects spreadsheet](https://docs.google.com/spreadsheets/d/1vzN-wZlS8K8ZyfExSV3hwXDenDEN9KyyAUJFTI6OjKU/edit#gid=1065639266) for details.

Resolves #298 