### PR TITLE
Update redirects for COVID-19 documents

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -347,11 +347,13 @@ rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers
 rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
 rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
 rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
 
 # Redirects for /resources/foia/
 rewrite ^/resources/foia/brgoals.pdf /resources/cms-content/documents/brgoals.pdf redirect;


### PR DESCRIPTION
Changing the redirect to point to the workplace safety plan and adding redirects for the documents in Wagtail.

All status of operations docs should now redirect to https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf