### PR TITLE
Redirects 17.5 and 17.6

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -415,6 +415,7 @@ rewrite ^/law/procedural_materials.shtml https://www.fec.gov/legal-resources/enf
 rewrite ^/law/proposed_rule_comment.shtml https://www.fec.gov/legal-resources/regulations/how-to-comment-on-proposed-rules-and-other-rulemaking-documents/ redirect;
 rewrite ^/law/recentdevelopments.shtml https://www.fec.gov/updates/ redirect;
 rewrite ^/law/ultimate_payee.pdf https://www.fec.gov/resources/updates/agendas/2013/mtgdoc_13-03.pdf redirect;
+rewrite ^/law/us_code/us_code.shtml https://www.fec.gov/data/legal/statutes/ redirect;
 
 # law/ alphabetical index court case pages redirects
 
@@ -897,6 +898,8 @@ rewrite ^/law/policy/enforcement_disclosure/doj.pdf https://www.fec.gov/resource
 rewrite ^/law/policy/formsrevisions2016/oconnor-formscomment.pdf https://www.fec.gov/resources/cms-content/documents/oconnor-formscomment.pdf redirect;
 rewrite ^/law/policy/iedisseminationdate/seiucomment.pdf https://www.fec.gov/resources/cms-content/documents/seiucomment.pdf redirect;
 rewrite ^/law/policy/iedisseminationdate/pomeranzcomment.pdf https://www.fec.gov/resources/cms-content/documents/pomeranzcomment.pdf redirect;
+rewrite ^/law/policy/nyspecial/nyspecialprimaryirdraft.pdf https://www.fec.gov/resources/updates/agendas/2013/mtgdoc_13-48.pdf redirect;
+rewrite ^/law/policy/technicalcorrections/drafttechcorrections2014.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=310744 redirect;
 
 # law/policy/embezzle/ redirects 
 rewrite ^/law/policy/embezzle/embezzlepolicy.pdf https://www.fec.gov/resources/cms-content/documents/embezzlementpolicy.pdf redirect;
@@ -925,9 +928,11 @@ rewrite ^/law/policy/enforcement/2009/witnesses.pdf https://www.fec.gov/updates/
 rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
 
 # law/policy/guidance/ redirects
+rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.doc https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
 rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
+
 
 # law/policy/internet09/ redirects
 rewrite ^/law/policy/internet09/070609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-6-09websitecomments.pdf redirect;
@@ -938,6 +943,7 @@ rewrite ^/law/policy/internet09/6-27-09websitecomments.pdf https://www.fec.gov/r
 rewrite ^/law/policy/internet09/6-26-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-26-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/agencyhearingextract.pdf https://www.fec.gov/resources/cms-content/documents/agencyhearingextract.pdf redirect;
 rewrite ^/law/policy/internet09/cathdemhearingcomment.pdf https://www.fec.gov/resources/cms-content/documents/comm7.pdf redirect;
+rewrite ^/law/policy/internet09/englecomments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072009.pdf https://www.fec.gov/resources/cms-content/documents/7-20-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments071809.pdf https://www.fec.gov/resources/cms-content/documents/7-18-09websitecomments.pdf redirect;
@@ -950,10 +956,14 @@ rewrite ^/law/policy/internet09/houghtalingcomment072709.pdf https://www.fec.gov
 rewrite ^/law/policy/internet09/notice_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-10.pdf redirect;
 rewrite ^/law/policy/internet09/notice_2009-14.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-14.pdf redirect;
 rewrite ^/law/policy/internet09/sunlighthearingcomment.pdf https://www.fec.gov/resources/cms-content/documents/comm28.pdf redirect;
+rewrite ^/law/policy/internet09/svobodacomments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf
+rewrite ^/law/policy/internet09/tonercomments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/webmanageremails.pdf https://www.fec.gov/resources/cms-content/documents/webmanageremails.pdf redirect;
 rewrite ^/law/policy/internet09/westcomments072909.pdf https://www.fec.gov/resources/cms-content/documents/7-29-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/witnesslist.pdf https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
 
 # law/policy/nationwideiereporting redirects 
+rewrite ^/law/policy/nationwideiereporting/draftinterpretiverule-reportingnationwideies-presprimaries.pdf https://www.fec.gov/resources/updates/agendas/2015/mtgdoc_15-50-b.pdf redirect;
 rewrite ^/law/policy/nationwideiereporting/draftnationwideiereporting.pdf https://www.fec.gov/resources/cms-content/documents/draftnationwideiereporting.pdf redirect;
 
 # law/policy/probablecause/ redirects 
@@ -964,9 +974,10 @@ rewrite ^/law/policy/probablecause/comm03.pdf https://www.fec.gov/resources/cms-
 rewrite ^/law/policy/probablecause/comm04.pdf https://www.fec.gov/resources/cms-content/documents/probablecause_comm4.pdf redirect;
 
 # law/policy/purposeofdisbursement redirects 
-rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-23_EO13892.pdf redirect;
 rewrite ^/law/policy/purposeofdisbursement/comment_cfi.pdf https://www.fec.gov/resources/cms-content/documents/comment_cfi.pdf redirect;
 rewrite ^/law/policy/purposeofdisbursement/comment_crp.pdf https://www.fec.gov/resources/cms-content/documents/comment_crp.pdf redirect;
+rewrite ^/law/policy/purposeofdisbursement/inadequate_purpose_list_3507.pdf https://www.fec.gov/help-candidates-and-committees/purposes-disbursements/ redirect;
+rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-23_EO13892.pdf redirect;
 
 # law/policy/suasponte redirects
 rewrite ^/law/policy/suasponte/comm2.pdf https://www.fec.gov/resources/cms-content/documents/suasponte_comm2.pdf redirect;
@@ -978,6 +989,7 @@ rewrite ^/pindex.shtml https://www.fec.gov/data/ redirect;
 rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
 
 # open/ redirects
+rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
 rewrite ^/open/documents/2016-MD-715%20-OGOV.pdf https://www.fec.gov/about/open/ redirect;
 rewrite ^/open/documents/FY-2016-Privacy-ManagementReport-to-OMB.pdf https://www.fec.gov/about/open/ redirect;
 rewrite ^/open/documents/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
@@ -986,7 +998,7 @@ rewrite ^/open/documents/PECF_monthly_report_2016.pdf https://www.fec.gov/resour
 rewrite ^/open/documents/PECF_monthly_report_2017.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2017.pdf redirect;
 rewrite ^/open/documents/PECF_monthly_report_2018.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2018.pdf redirect;
 rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
-rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
+rewrite ^/open/documents/Yearly-Long-Term-Budget-Estimates-for-PECF-FY2017_2027.pdf https://www.fec.gov/resources/cms-content/documents/Yearly-Long-Term-Budget-Estimates-for-PECF-FY2017_2027.pdf redirect;
 
 # pages/ redirects
 rewrite ^/pages/anreport.shtml https://www.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/ redirect;
@@ -998,12 +1010,43 @@ rewrite ^/pages/statefiling.shtml https://www.fec.gov/introduction-campaign-fina
 # pages/bcra/ redirects
 rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
 rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
+rewrite ^/pages/bcra/bcra_faq.htm https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/bcra/bcra_fea.dcf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/bcra_form_2.fec https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/bcra_interim_cand.dcf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/draft_form_3x_instructions.doc https://www.fec.gov/updates/january-30-2003-open-meeting/ redirect;
+rewrite ^/pages/bcra/educational_outreach_bcra.htm https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
+rewrite ^/pages/bcra/electioneering_communications.htm https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
+rewrite ^/pages/bcra/electronic_filing_examples_bcra.htm https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
+rewrite ^/pages/bcra/fea_3x.fec https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/fea_h5.fec https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/fea_h6.fec https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/fea_nonallocable_disb.fec https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/fec_form_1_draft_instructions.doc https://www.fec.gov/updates/january-30-2003-open-meeting/ redirect;
+rewrite ^/pages/bcra/fec_form_2_draft_instructions.doc https://www.fec.gov/updates/january-30-2003-open-meeting/ redirect;
 rewrite ^/pages/bcra/form_9_instructions.doc https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
 rewrite ^/pages/bcra/fr67n230p71075_interim_reporting_policy.pdf https://www.fec.gov/resources/cms-content/documents/fr67n230p71075_interim_reporting_policy.pdf redirect;
+rewrite ^/pages/bcra/interim_reporting_policy.htm https://www.fec.gov/resources/cms-content/documents/fr67n230p71075_interim_reporting_policy.pdf redirect;
 rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
+rewrite ^/pages/bcra/major_resources_bcra.htm https://www.fec.gov/legal-resources/ redirect;
 rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/pages/bcra/proposed_formats.html https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
+rewrite ^/pages/bcra/sc_order_in_02-1674.doc https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pages/bcra/schedule_e_form_5_instructions.doc https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+
+# /pages/bcra/rulemakings/ redirects
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates_2010.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates_2011.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates_2013.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates_midterm.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates_prez.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/charts_fea_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/pages/bcra/rulemakings/consolidated_reporting.shtml https://sers.fec.gov/fosers/showpdf.htm?docid=1024 redirect;
+rewrite ^/pages/bcra/rulemakings/ECs_WRTL_Exemption_Examples.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
+rewrite ^/pages/bcra/rulemakings/presidential_rules.htm https://sers.fec.gov/fosers/showpdf.htm?docid=8532 redirect;
+rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/chronological-index-2000-2009-ejs/ redirect;
 
 # pages/budget/ redirects
 rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
@@ -1014,53 +1057,88 @@ rewrite ^/pages/brochures/admin_fines.shtml https://www.fec.gov/legal-resources/
 rewrite ^/pages/brochures/adr.shtml https://www.fec.gov/legal-resources/enforcement/alternative-dispute-resolution/ redirect;
 rewrite ^/pages/brochures/ao_brochure.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
 rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
+rewrite ^/pages/brochures/aos.pdf https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
+rewrite ^/pages/brochures/auditprocess.shtml https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;
 rewrite ^/pages/brochures/audit_process.pdf https://www.fec.gov/resources/cms-content/documents/audit_process.pdf redirect;
+rewrite ^/pages/brochures/bcra_brochure.pdf https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/pages/brochures/bestpractices.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
+rewrite ^/pages/brochures/BestPracticesforCommitteeManagement.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
+rewrite ^/pages/brochures/best_practices.pdf https://www.fec.gov/updates/best-practices-committee-management/ redirect;
+rewrite ^/pages/brochures/biennial_limit_brochure.pdf https://www.fec.gov/legal-resources/court-cases/mccutcheon-et-al-v-fec/ redirect;
 rewrite ^/pages/brochures/brochures.shtml https://www.fec.gov/help-candidates-and-committees/guides redirect; 
 rewrite ^/pages/brochures/candregis.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/ redirect;
+rewrite ^/pages/brochures/candidate_registration_brochure.pdf https://www.fec.gov/help-candidates-and-committees/registering-candidate/ redirect;
 rewrite ^/pages/brochures/checkoff.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/#primary-matching-funds redirect;
+rewrite ^/pages/brochures/checkoff_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/citizens.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 rewrite ^/pages/brochures/citizens_guide_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 rewrite ^/pages/brochures/citngui1.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/complain.shtml https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
 rewrite ^/pages/brochures/complaint_brochure.pdf https://www.fec.gov/legal-resources/enforcement/complaints-process/how-to-file-complaint-with-fec/ redirect;
+rewrite ^/pages/brochures/compliance_nonfec.pdf https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/brochures/compliance_nonfec.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/brochures/contrib.gif https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/pages/brochures/contrib.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
 rewrite ^/pages/brochures/contriblimits.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-limits/ redirect;
+rewrite ^/pages/brochures/contriblimits0304.jpg https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/pages/brochures/contriblimitschart.htm https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/pages/brochures/contriblimits.jpg https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
+rewrite ^/pages/brochures/ContributionLimits2003-2004.htm https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/pages/brochures/contributions_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
 rewrite ^/pages/brochures/contributions_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts redirect;
 rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
 rewrite ^/pages/brochures/delegate_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/delegate-activity/ redirect;
+rewrite ^/pages/brochures/documents/ChartonContributionLimitsfor2003-04.doc https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/pages/brochures/ec-brochure.pdf https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/other-filers/making-electioneering-communications/ redirect;
-rewrite ^/pages/brochures/fec_feca_brochure.pdf https://transition.fec.gov/pages/brochures/fecfeca.shtml redirect;
+rewrite ^/pages/brochures/ExamplesofHowtoCalculateFines.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
+rewrite ^/pages/brochures/fec_feca_brochure.pdf https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/brochures/fec_feca_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/brochures/fecfeca.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/brochures/fecfeca1.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/brochures/flowchart.gif https://www.fec.gov/legal-resources/enforcement/alternative-dispute-resolution/ redirect;
 rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/help-candidates-and-committees/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/foreign1.shtml https://www.fec.gov/help-candidates-and-committees/foreign-nationals/ redirect;
+rewrite ^/pages/brochures/foreign_nat_brochure.pdf https://www.fec.gov/help-candidates-and-committees/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/ie_brochure.pdf https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-independent-expenditures/ redirect;
 rewrite ^/pages/brochures/internetcomm.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 rewrite ^/pages/brochures/internetcomm.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
+rewrite ^/pages/brochures/internalcontrols.pdf https://www.fec.gov/help-candidates-and-committees/keeping-records/misappropriated-funds/ redirect;
 rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/help-candidates-and-committees/joint-fundraising-candidates-political-committees/ redirect;
 rewrite ^/pages/brochures/jointfundraising_brochure.pdf https://www.fec.gov/help-candidates-and-committees/joint-fundraising-candidates-political-committees/ redirect;
 rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
+rewrite ^/pages/brochures/local_party_activity_brochure.pdf https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
 rewrite ^/pages/brochures/notices.shtml https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers redirect;
+rewrite ^/pages/brochures/orientation0508.pps https://www.fec.gov/about/ redirect;
 rewrite ^/pages/brochures/partner.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
 rewrite ^/pages/brochures/partnership.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
 rewrite ^/pages/brochures/partnership_brochure.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
 rewrite ^/pages/brochures/partnership_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/partnership-llc-contributions/ redirect;
 rewrite ^/pages/brochures/pubfund.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
-rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits-2016/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2004.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2007.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2008.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2011.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2012.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2015.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
+rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/presidential-spending-limits/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/rad_brochure.pdf https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
+rewrite ^/pages/brochures/ReportsAnalysisDivision.shtml https://www.fec.gov/resources/cms-content/documents/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf redirect;
 rewrite ^/pages/brochures/sale_and_use_brochure.pdf https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
+rewrite ^/pages/brochures/ssfvnonconnected.pdf https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
+rewrite ^/pages/brochures/submission_dates_2016.pdf https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/establishing-eligibility-presidential-primary-matching-funds/ redirect;
 rewrite ^/pages/brochures/testing_waters.pdf https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
 rewrite ^/pages/brochures/TestingTheWaters.shtml https://www.fec.gov/help-candidates-and-committees/registering-candidate/testing-the-waters-possible-candidacy/ redirect;
 rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/volact.shtml https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
+rewrite ^/pages/brochures/volact1.shtml https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/ redirect;
 rewrite ^/pages/brochures/volunteer_activity_brochure.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 rewrite ^/pages/brochures/volunteer_activity_brochure_spanish.pdf https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/volunteer-activity/ redirect;
 
@@ -1068,10 +1146,13 @@ rewrite ^/pages/brochures/volunteer_activity_brochure_spanish.pdf https://www.fe
 rewrite ^/pages/fecrecord/fecrecord.shtml https://www.fec.gov/updates/record-archive-1975-2004/ redirect;
 
 # pages/hearings/ redirects
+rewrite ^/pages/hearings/candidatenonfederalfundraiser.shtml https://www.fec.gov/updates/march-16-2010-public-hearing-federal-officeholders-and-candidates-nonfederal-fundraising-events/ redirect;
 rewrite ^/pages/hearings/hearingtranscript09-17-09.pdf https://www.fec.gov/resources/cms-content/documents/hearingtranscript09-17-09.pdf redirect;
 rewrite ^/pages/hearings/hearing_transcript20090825.pdf https://www.fec.gov/resources/cms-content/documents/hearing_transcript20090825.pdf redirect;
+rewrite ^/pages/hearings/hearing_transcript08-10-2009.pdf https://www.fec.gov/resources/cms-content/documents/hearing_transcript20090825.pdf redirect;
 rewrite ^/pages/hearings/internethearing.shtml https://www.fec.gov/updates/7-29-8-25-2009-public-hearings-website-internet-communications-improvement-initiative/ redirect;
 rewrite ^/pages/hearings/internethearingcomments.shtml https://www.fec.gov/legal-resources/policy-other-guidance/website-internet-communications-improvement-initiative-comments/ redirect;
+rewrite ^/pages/hearings/McCutcheonRulemakingPublicHearing.shtml https://www.fec.gov/updates/february-11-2015-public-hearing-mccutcheon-v-fec-advance-notice-proposed-rulemaking/ redirect;
 rewrite ^/pages/hearings/opensession20091105.pdf https://www.fec.gov/resources/cms-content/documents/opensession20091105.pdf redirect;
 rewrite ^/pages/hearings/statusofwebsiteinitiative-bluedraftrev.pdf https://www.fec.gov/resources/updates/agendas/2009/mtgdoc0974.pdf redirect;
 
@@ -1080,6 +1161,15 @@ rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;
 
 # pages/procure redirects
 rewrite ^/pages/procure/procure.shtml https://www.fec.gov/about/reports-about-fec/procurement-and-contracting/ redirect;
+rewrite ^/pages/procure/publicreports/fair_act_fy12.pdf https://www.fec.gov/about/reports-about-fec/procurement-and-contracting/ redirect;
+rewrite ^/pages/procure/publicreports/fair_act_fy14.pdf https://www.fec.gov/resources/about-fec/reports/fair_act_fy14.pdf redirect;
+rewrite ^/pages/procure/publicreports/fair_act_fy15.pdf https://www.fec.gov/resources/about-fec/reports/fair_act_fy15.pdf redirect;
+rewrite ^/pages/procure/publicreports/fair_act_fy16.pdf https://www.fec.gov/resources/about-fec/reports/fair_act_fy16.pdf redirect;
+rewrite ^/pages/procure/publicreports/fair_act_fy17.pdf https://www.fec.gov/resources/cms-content/documents/fair_act_fy17.pdf redirect;
+rewrite ^/pages/procure/publicreports/FEC_FY11_Services_Contract_Inventory_Report.pdf https://www.fec.gov/resources/about-fec/reports/FEC_FY11_Services_Contract_Inventory_Report.pdf redirect;
+rewrite ^/pages/procure/publicreports/FEC_FY12_Service_Contract_Inventory_Report.pdf https://www.fec.gov/resources/about-fec/reports/FEC_FY12_Service_Contract_Inventory_Report.pdf redirect;
+rewrite ^/pages/procure/publicreports/FEC_FY15_Service_Contract_Inventory_Report.pdf https://www.fec.gov/resources/about-fec/reports/FEC_FY15_Service_Contract_Inventory_Report.pdf redirect;
+rewrite ^/pages/procure/publicreports/FEC_Service_Orders_ Over_25k_FY2010_rev02.pdf https://www.fec.gov/resources/about-fec/reports/FEC_Service_Orders_Over_25k_FY2010_rev02.pdf redirect;
 
 # pdf/ Audit thresholds redirects
 rewrite ^/pdf/2016title26materialitythresholdsapproved09132016_redacted.pdf https://www.fec.gov/resources/cms-content/documents/2016_audit_materiality_thresholds_title_26_presidential.pdf redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -943,7 +943,6 @@ rewrite ^/law/policy/internet09/6-27-09websitecomments.pdf https://www.fec.gov/r
 rewrite ^/law/policy/internet09/6-26-09websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/6-26-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/agencyhearingextract.pdf https://www.fec.gov/resources/cms-content/documents/agencyhearingextract.pdf redirect;
 rewrite ^/law/policy/internet09/cathdemhearingcomment.pdf https://www.fec.gov/resources/cms-content/documents/comm7.pdf redirect;
-rewrite ^/law/policy/internet09/englecomments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments072009.pdf https://www.fec.gov/resources/cms-content/documents/7-20-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments071809.pdf https://www.fec.gov/resources/cms-content/documents/7-18-09websitecomments.pdf redirect;
@@ -952,6 +951,7 @@ rewrite ^/law/policy/internet09/comments071609.pdf https://www.fec.gov/resources
 rewrite ^/law/policy/internet09/comments071409.pdf https://www.fec.gov/resources/cms-content/documents/7-14-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/comments070809.pdf https://www.fec.gov/resources/cms-content/documents/7-8-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/crpcomment082109.pdf https://www.fec.gov/resources/cms-content/documents/8-21-09websitecomments.pdf redirect;
+rewrite ^/law/policy/internet09/englecomments072109.pdf https://www.fec.gov/resources/cms-content/documents/7-21-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/houghtalingcomment072709.pdf https://www.fec.gov/resources/cms-content/documents/7-27-09websitecomments.pdf redirect;
 rewrite ^/law/policy/internet09/notice_2009-10.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-10.pdf redirect;
 rewrite ^/law/policy/internet09/notice_2009-14.pdf https://www.fec.gov/resources/cms-content/documents/notice_2009-14.pdf redirect;
@@ -989,7 +989,6 @@ rewrite ^/pindex.shtml https://www.fec.gov/data/ redirect;
 rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
 
 # open/ redirects
-rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
 rewrite ^/open/documents/2016-MD-715%20-OGOV.pdf https://www.fec.gov/about/open/ redirect;
 rewrite ^/open/documents/FY-2016-Privacy-ManagementReport-to-OMB.pdf https://www.fec.gov/about/open/ redirect;
 rewrite ^/open/documents/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
@@ -999,6 +998,7 @@ rewrite ^/open/documents/PECF_monthly_report_2017.pdf https://www.fec.gov/resour
 rewrite ^/open/documents/PECF_monthly_report_2018.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2018.pdf redirect;
 rewrite ^/open/documents/PECF_monthly_report_2019.pdf https://www.fec.gov/resources/cms-content/documents/PECF_monthly_report_2019.pdf redirect;
 rewrite ^/open/documents/Yearly-Long-Term-Budget-Estimates-for-PECF-FY2017_2027.pdf https://www.fec.gov/resources/cms-content/documents/Yearly-Long-Term-Budget-Estimates-for-PECF-FY2017_2027.pdf redirect;
+rewrite ^/open/index.shtml https://www.fec.gov/open/ redirect;
 
 # pages/ redirects
 rewrite ^/pages/anreport.shtml https://www.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/ redirect;
@@ -1009,7 +1009,6 @@ rewrite ^/pages/statefiling.shtml https://www.fec.gov/introduction-campaign-fina
 
 # pages/bcra/ redirects
 rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
-rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
 rewrite ^/pages/bcra/bcra_faq.htm https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/pages/bcra/bcra_fea.dcf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
 rewrite ^/pages/bcra/bcra_form_2.fec https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
@@ -1034,6 +1033,7 @@ rewrite ^/pages/bcra/proposed_formats.html https://www.fec.gov/help-candidates-a
 rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
 rewrite ^/pages/bcra/sc_order_in_02-1674.doc https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pages/bcra/schedule_e_form_5_instructions.doc https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
+rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
 
 # /pages/bcra/rulemakings/ redirects
 rewrite ^/pages/bcra/rulemakings/charts_fea_dates_2010.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;


### PR DESCRIPTION
Transition redirects for stray files in  law/policy and pages/ directories. See Transition Inventory, lines 165-461 for complete list.

To test: Check for syntax and for alphabetical order of redirects.