### PR TITLE
Adds www redirects for older forms

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -274,6 +274,7 @@ rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf /reso
 rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf /resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
 rewrite ^/pdf/1997_Enforcement_Manual.pdf /resources/cms-content/documents/1997_enforcement_manual.pdf redirect;
 rewrite ^/pdf/Additional_Enforcement_Materials.pdf /resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
+rewrite ^/pdf/ar1995.pdf https://www.fec.gov/resources/cms-content/documents/ar95.pdf redirect;
 rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf /resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
 rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf /resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
 rewrite ^/pdf/audit_threshold_title26_2008.pdf /resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -289,9 +289,20 @@ rewrite ^/pdf/RAD_Procedures_2013-14.pdf /resources/cms-content/documents/2013-2
 rewrite ^/pdf/RAD_Procedures.pdf /resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
 
 # Redirects for /pdf/forms/
+rewrite ^/pdf/forms/fecfrm1auth.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1party.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm10i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm10.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm2.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm5.pdf redirect;
 
 # Redirects for /pdf/record/
 rewrite ^/pdf/record/1996/index96_1.htm /resources/cms-content/documents/index1996.pdf redirect;


### PR DESCRIPTION
Some older forms and one annual report had names that didn't follow naming conventions or are being redirected to a court case page instead of a form, so broader redirects did not work. Wagtail redirect did not work either, so submitting this PR.

See lines 474 and 540-554 of the transition inventory spreadsheet.