### PR TITLE
Correcting 18.4 transition redirects after testing

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1212,10 +1212,10 @@ rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/federal-election-c
 rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm2.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
 rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm5.pdf redirect;
-rewrite ^/pdf/forms/fecfrm9i_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm9.pdf redirect;
+rewrite ^/pdf/forms/fecfrm9i_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm9i.pdf redirect;
 
 # pdf/ general redirects
 rewrite ^/pdf/00adminfines.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=11146 redirect;
@@ -1230,6 +1230,7 @@ rewrite ^/pdf/67fr05445.pdf https://www.fec.gov/resources/cms-content/documents/
 rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
 rewrite ^/pdf/ar1995.pdf https://www.fec.gov/resources/cms-content/documents/ar95.pdf redirect;
 rewrite ^/pdf/Audit_Procedures.pdf https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
+rewrite ^/pdf/budget2001.PDF https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
 rewrite ^/pdf/cca.pdf https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pdf/cand_guide_supp.pdf https://www.fec.gov/help-candidates-and-committees/guides/ redirect;
 rewrite ^/pdf/cfr11.pdf https://www.fec.gov/legal-resources/regulations/ redirect;


### PR DESCRIPTION
One redirect was forgotten and the redirect URL was off by one letter for three others.

See lines 477, 551, 552 and 554 of the transition inventory spreadsheet