### PR TITLE
Fixing Form 9 instructions redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1215,7 +1215,7 @@ rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/do
 rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
 rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm5.pdf redirect;
-rewrite ^/pdf/forms/fecfrm9i_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm9i.pdf redirect;
+rewrite ^/pdf/forms/fecfrm9i_06.pdf https://www.fec.gov/resources/cms-content/documents/fecform9i.pdf redirect;
 
 # pdf/ general redirects
 rewrite ^/pdf/00adminfines.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=11146 redirect;


### PR DESCRIPTION
Needed to put an "o" into the URL to fix this redirect 