### PR TITLE
Adds www redirects for old version of instructions

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -301,7 +301,9 @@ rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/federal-election-c
 rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
 rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm2.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
 rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm5.pdf redirect;
 
 # Redirects for /pdf/record/


### PR DESCRIPTION
Unable to do via Wagtail due to broader redirect.

Redirects old form 3X instructions to current version