### PR TITLE
Fix syntax for broad transition redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1588,7 +1588,7 @@ rewrite ^/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redire
 rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;
 
 # /press/archive/ broader redirects
-rewrite ^/press/archive/([0-9]{4})/(.*) https://www.fec.gov/resources/news_releases/$1/$2 redirect;
+rewrite "^/press/archive/([0-9]{4})/(.*)" https://www.fec.gov/resources/news_releases/$1/$2 redirect;
 
 # /press/summaries/ broader redirects 
 rewrite "^/press/summaries/([0-9]{4})/ElectionCycle/([0-9]{1,2})m_CongCand.shtml" https://www.fec.gov/campaign-finance-data/congressional-candidate-data-summary-tables/?year=$1&segment=$2 redirect;


### PR DESCRIPTION
Realized that the proxy build was failing due to incorrect syntax on the press news release redirect. Once this is put in, it should fix the build.