### PR TITLE
Adds redirects for 2022 admin fines

### DIFF
--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -7,3 +7,6 @@ rewrite ^/regulations/111-44/2020-annual-111 https://www.ecfr.gov/cgi-bin/text-i
 rewrite ^/regulations/111-24/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
 rewrite ^/regulations/111-43/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
 rewrite ^/regulations/111-44/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;
+rewrite ^/regulations/111-24/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
+rewrite ^/regulations/111-43/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
+rewrite ^/regulations/111-44/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;


### PR DESCRIPTION
New admin fines took effect on 12/29/2022. This PR adds the redirects for the three regulations that are affected to redirect their 2022 e-regs version to the eCFR.