### PR TITLE
Add partial redirects for admin fines

### DIFF
--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -10,3 +10,6 @@ rewrite ^/regulations/111-44/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-i
 rewrite ^/regulations/111-24/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
 rewrite ^/regulations/111-43/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
 rewrite ^/regulations/111-44/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;
+rewrite ^/regulations/partial/111-24/2022-annual-111 https://transition.fec.gov/regulations/page-ref-111-24.html redirect;
+rewrite ^/regulations/partial/111-43/2022-annual-111 https://transition.fec.gov/regulations/page-ref-111-43.html redirect;
+rewrite ^/regulations/partial/111-44/2022-annual-111 https://transition.fec.gov/regulations/page-ref-111-44.html redirect;


### PR DESCRIPTION
Resolves #342 

Adds a partial redirect so that when navigating in the regulations app to each of these sections, it will display the correct fines information.