### PR TITLE
Add redirects for archived prior notices reporting dates

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1532,6 +1532,24 @@ rewrite ^/info/roundtable_materials/(.*) https://www.fec.gov/help-candidates-and
 rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
 rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treasurers$1 redirect;
 
+# info/ prior notices broader redirects
+rewrite ^/info/charts_cc_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_cc_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_cc_dates_prez.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_fea_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ec_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ec_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ec_dates_prez.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ec_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ie_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_primary_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_primary_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/report_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ie_dates.htm https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ie_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ie_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ie_dates_prez.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+
 # law/ broader redirects
 rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
@@ -1582,6 +1600,9 @@ rewrite ^/MUR/.* https://www.fec.gov/data/legal/search/enforcement/ redirect;
 # pages/bcra webform broader redirects
 rewrite ^/pages/bcra/bcra_webform(.*).pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
 rewrite ^/pages/bcra/(.*) https://www.fec.gov/resources/legal-resources/litigation/bcra/$1 redirect;
+
+# pages/report_notices prior notices broader redirects
+rewrite ^/pages/report_notices/* https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 
 # pdf/ broader redirects
 rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;


### PR DESCRIPTION
Resolves #345 

Add redirects for archived prior notices on transition from 2018 and prior.