### PR TITLE
Fix legislative history PDF redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1269,9 +1269,9 @@ rewrite ^/pdf/aos/Sample_ao.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=65
 
 # pdf/legislative_hist/ redirects
 rewrite ^/pdf/legislative_hist/legislative_history_1971.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1971.pdf redirect;
-rewrite ^/pdf/legislative_hist/legislative_history_1974.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1971.pdf redirect;
-rewrite ^/pdf/legislative_hist/legislative_history_1976.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1971.pdf redirect;
-rewrite ^/pdf/legislative_hist/legislative_history_1979.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1971.pdf redirect;
+rewrite ^/pdf/legislative_hist/legislative_history_1974.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1974.pdf redirect;
+rewrite ^/pdf/legislative_hist/legislative_history_1976.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1976.pdf redirect;
+rewrite ^/pdf/legislative_hist/legislative_history_1979.pdf https://www.fec.gov/resources/legal-resources/legislative-history/legislative_history_1979.pdf redirect;
 
 # pdf/nprm/ redirects
 rewrite ^/pdf/nprm/emilyslistrepeal/notice_2009-30.pdf https://www.fec.gov/resources/legal-resources/rulemakings/nprm/emilyslistrepeal/notice_2009-30.pdf redirect;


### PR DESCRIPTION
The legislative history PDF redirects needed to go to their corresponding PDF files on the content s3. This PR corrects the resulting file.