### PR TITLE
Fix prior notice transition redirects

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1533,18 +1533,18 @@ rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-commi
 rewrite ^/info/tips/(.*) https://www.fec.gov/updates/?update_type=tips-for-treasurers$1 redirect;
 
 # info/ prior notices broader redirects
-rewrite ^/info/charts_cc_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_cc_dates_(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_cc_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_cc_dates_prez.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/charts_fea_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/charts_ec_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_fea_dates_(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ec_dates_(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_ec_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_ec_dates_prez.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_ec_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/charts_ie_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/charts_primary_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_ie_dates_(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/charts_primary_dates_(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_primary_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
-rewrite ^/info/report_dates_([0-9]{4}) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
+rewrite ^/info/report_dates_(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_ie_dates.htm https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_ie_dates.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/charts_ie_dates_special.shtml https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;


### PR DESCRIPTION
I needed to fix the failing dev build. I just realized that since I was trying to do a specific pattern match, it wouldn't allow the resulting redirect to the H4CC dates and deadlines page. Therefore, I needed to do a generic capture of the url and redirect all to H4CC dates and deadlines page. I tested and it built ok.