### PR TITLE
Updates and cleans up www redirects

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -7,7 +7,7 @@ rewrite ^/fosers/ http://sers.fec.gov/fosers/ redirect;
 rewrite ^/pindex.shtml /data/ redirect;
 rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;
 rewrite ^/privacy.shtml /about/privacy-and-security-policy redirect;
-rewrite ^/support/DataConversionTools.shtml https://www.fec.gov/help-candidates-and-committees/filing-reports/data-conversion-tools/ redirect;
+rewrite ^/support/DataConversionTools.shtml /help-candidates-and-committees/filing-reports/data-conversion-tools/ redirect;
 rewrite ^/support /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/working.shtml /about/#working-with-the-fec redirect;
 
@@ -17,7 +17,7 @@ rewrite ^/about/offices/offices.shtml /about/leadership-and-structure/fec-office
 rewrite ^/about/offices/org_chart.shtml /about/leadership-and-structure/fec-offices/ redirect;
 
 # Redircts for /af/
-rewrite ^/af/index.shtml https://www.fec.gov/legal-resources/enforcement/administrative-fines/ redirect;
+rewrite ^/af/index.shtml /legal-resources/enforcement/administrative-fines/ redirect;
 rewrite ^/af/af_calc.shtml /legal-resources/enforcement/administrative-fines/calculating-administrative-fines/ redirect;
 
 # Redirects for /agenda/
@@ -50,16 +50,16 @@ rewrite ^/ans/answers_filing.shtml /help-candidates-and-committees/ redirect;
 rewrite ^/ans/answers_public_funding.shtml /introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 
 # Redirects for /audio/
-rewrite ^/audio/images/audio.png https://transition.fec.gov/images/audio.png redirect;
+rewrite ^/audio/images/audio.png /resources/cms-content/images/classic_audio.original.png redirect;
 
 # Redirects for /auditsearch/
 rewrite ^/auditsearch/auditsearch.do /legal-resources/enforcement/audit-search/ redirect;
 
-# Redirects for /audits/
-rewrite ^/audits/audit_reports.shtml https://transition.fec.gov/audits/audit_reports.shtml redirect;
-rewrite ^/audits/audit_reports_auth.shtml https://transition.fec.gov/audits/audit_reports_auth.shtml redirect;
-rewrite ^/audits/audit_reports_pres.shtml https://transition.fec.gov/audits/audit_reports_pres.shtml redirect;
-rewrite ^/audits/audit_reports_unauth.shtml https://transition.fec.gov/audits/audit_reports_unauth.shtml redirect;
+# Redirects for /audits/ 
+rewrite ^/audits/audit_reports.shtml /legal-resources/enforcement/audit-reports/ redirect;
+rewrite ^/audits/audit_reports_auth.shtml /legal-resources/enforcement/audit-reports/authorized-committee-audit-reports redirect;
+rewrite ^/audits/audit_reports_pres.shtml /legal-resources/enforcement/audit-reports/publicly-financed-committee-audit-reports redirect;
+rewrite ^/audits/audit_reports_unauth.shtml /legal-resources/enforcement/audit-reports/unauthorized-committee-audit-reports redirect;
 rewrite ^/audits/understand_pres_audits.shtml /legal-resources/enforcement/audit-reports/understanding-presidential-primary-audit-report/ redirect;
 
 # Redirects for /calendar/
@@ -109,20 +109,20 @@ rewrite ^/em/respondent_guide.pdf /resources/cms-content/documents/respondent_gu
 rewrite ^/fecig/fecig.shtml /office-inspector-general/ redirect;
 
 # Redirects for /finance/
+rewrite ^/finance/2012matching/2012matching.shtml /campaign-finance-data/presidential-matching-fund-submissions/2012-presidential-matching-fund-submissions/ redirect;
+rewrite ^/finance/2008matching/2008matching.shtml /campaign-finance-data/presidential-matching-fund-submissions/2008-presidential-matching-fund-submissions/ redirect;
+rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml /campaign-finance-data/presidential-matching-fund-submissions/2016-presidential-matching-fund-submissions/ redirect;
+rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml /campaign-finance-data/presidential-matching-fund-submissions/2004-presidential-matching-fund-submissions/ redirect;
 rewrite ^/finance/disclosure/candcmte_info.shtml /data/ redirect;
-rewrite ^/finance/2012matching/2012matching.shtml https://transition.fec.gov/finance/2012matching/2012matching.shtml redirect;
-rewrite ^/finance/2008matching/2008matching.shtml https://transition.fec.gov/finance/2008matching/2008matching.shtml redirect;
-rewrite ^/finance/disclosure/2016MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2016MatchingFundSubmissions.shtml redirect;
-rewrite ^/finance/disclosure/2004MatchingFundSubmissions.shtml https://transition.fec.gov/finance/disclosure/2004MatchingFundSubmissions.shtml redirect;
 
 # Redirects for /general/
-rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
+rewrite ^/general/library.shtml /introduction-campaign-finance/how-to-research-public-records/ redirect;
 rewrite ^/general/FederalElections2016.shtml /introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/general/whatsnew.shtml /updates/ redirect;
 
-# Redirects for /images/
-rewrite ^/images/transcript_icon.png https://transition.fec.gov/images/transcript_icon.png redirect;
-rewrite ^/images/play_icon.png https://transition.fec.gov/images/play_icon.png redirect;
+# Redirects for /images/ 
+rewrite ^/images/transcript_icon.png /resources/cms-content/images/classic_transcript_icon.original.png redirect;
+rewrite ^/images/play_icon.png /resources/cms-content/images/classic_play_icon.original.png redirect;
 
 # Redirects for /info/
 rewrite ^/info/apptwo.htm /resources/cms-content/documents/legrec1993.pdf redirect; 
@@ -136,14 +136,14 @@ rewrite ^/info/charts_441ad_2012.shtml /resources/cms-content/documents/fedreg_n
 rewrite ^/info/charts_441ad_2011.shtml /resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
 rewrite ^/info/charts_441ad_2010.shtml /resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
 rewrite ^/info/charts_441ad.shtml /resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+rewrite ^/info/compliance.shtml /help-candidates-and-committees/ redirect; 
 rewrite ^/info/contriblimitschart1718.pdf /help-candidates-and-committees/candidate-taking-receipts/archived-contribution-limits/ redirect;
 rewrite ^/info/elearning.shtml /help-candidates-and-committees/trainings/#e-learning-videos redirect;
 rewrite ^/info/ElectionDate/ /help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/espanol.shtml https://www.fec.gov/ redirect;
 rewrite ^/info/FECWebinars.shtml /help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
-rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
 rewrite ^/info/filing.shtml /help-candidates-and-committees/ redirect;
+rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
 rewrite ^/info/mission.shtml /about/mission-and-history/ redirect;
 rewrite ^/info/outreach.shtml /help-candidates-and-committees/trainings/ redirect;
 rewrite ^/info/publications.shtml /help-candidates-and-committees/guides/ redirect;
@@ -159,17 +159,9 @@ rewrite ^/info/guidance/hlogabundling.shtml /help-candidates-and-committees/lobb
 rewrite ^/info/guidance/recountreporting.shtml /help-candidates-and-committees/candidate-taking-receipts/recounts-and-contested-elections/ redirect;
 
 # Redirects for /law/
-rewrite ^/law/law.shtml /legal-resources/ redirect;
-rewrite ^/law/cfr/cfr.shtml /regulations redirect;
-rewrite ^/law/cfr/cfr_2009.pdf https://www.govinfo.gov/content/pkg/CFR-2009-title11-vol1/pdf/CFR-2009-title11-vol1.pdf redirect;
-rewrite ^/law/cfr/cfr_2008.pdf https://www.govinfo.gov/content/pkg/CFR-2008-title11-vol1/pdf/CFR-2008-title11-vol1.pdf redirect;
-rewrite ^/law/cfr/2014cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2014-title11-vol1/pdf/CFR-2014-title11-vol1.pdf redirect;
-rewrite ^/law/cfr/11cfr2015.pdf https://www.govinfo.gov/content/pkg/CFR-2015-title11-vol1/pdf/CFR-2015-title11-vol1.pdf redirect;
-rewrite ^/law/cfr/11_cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2010-title11-vol1/pdf/CFR-2010-title11-vol1.pdf redirect;
-rewrite ^/law/ej_compilation/2004/2004-05_Admin_Fines_Extension.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=36188 redirect;
-rewrite ^/law/ej_compilation/2001/2001-18_Admin_Fines_Extension.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=7419 redirect;
 rewrite ^/law/draftaos.shtml /legal-resources/advisory-opinions-process/#draft-answers-to-advisory-opinion-requests redirect;
 rewrite ^/law/feca/feca.shtml /legal-resources/legislation/ redirect;
+rewrite ^/law/law.shtml /legal-resources/ redirect;
 rewrite ^/law/legalconsideration.shtml /legal-resources/policy-other-guidance/requests-legal-consideration/ redirect;
 rewrite ^/law/litigation.shtml /legal-resources/court-cases/ redirect;
 rewrite ^/law/nonfederalfundraisingfaq2.shtml /help-candidates-and-committees/making-disbursements/fundraising-other-candidates-committees/ redirect;
@@ -177,31 +169,41 @@ rewrite ^/law/policy.shtml /legal-resources/policy-other-guidance/ redirect;
 rewrite ^/law/procedural_materials.shtml /legal-resources/enforcement/procedural-materials/ redirect;
 rewrite ^/law/recentdevelopments.shtml /legal-resources/ redirect;
 
-# Redirects for /law/cfr/ej_compilation/
-rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2010/notice_2010-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2008/notice_2008-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2008-04.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
+# Redirects for /law/cfr/
+rewrite ^/law/cfr/11_cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2010-title11-vol1/pdf/CFR-2010-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/11cfr2015.pdf https://www.govinfo.gov/content/pkg/CFR-2015-title11-vol1/pdf/CFR-2015-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/2014cfr.pdf https://www.govinfo.gov/content/pkg/CFR-2014-title11-vol1/pdf/CFR-2014-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/cfr.shtml /regulations redirect;
+rewrite ^/law/cfr/cfr_2009.pdf https://www.govinfo.gov/content/pkg/CFR-2009-title11-vol1/pdf/CFR-2009-title11-vol1.pdf redirect;
+rewrite ^/law/cfr/cfr_2008.pdf https://www.govinfo.gov/content/pkg/CFR-2008-title11-vol1/pdf/CFR-2008-title11-vol1.pdf redirect;
 
+
+# Redirects for /law/cfr/ej_compilation/
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf /resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf /resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2015/notice2015-01.pdf /resources/cms-content/documents/fedreg_notice_2015-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf /resources/cms-content/documents/fedreg_notice_2014-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf /resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf /resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf /resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf /resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf /resources/cms-content/documents/fedreg_notice_2012-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf /resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf /resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf /resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf /resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf /resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-02.pdf /resources/cms-content/documents/fedreg_notice_2010-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf /resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2008/notice_2008-04.pdf /resources/cms-content/documents/fedreg_notice_2008-04.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf /resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf /resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf /resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-2.pdf /resources/cms-content/documents/fedreg_notice_2007-02.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2006/notice_2006-03.pdf /resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2005/2005-7.pdf /resources/cms-content/documents/fedreg_notice_2005-07.pdf redirect;
+rewrite ^/law/ej_compilation/2004/2004-05_Admin_Fines_Extension.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=36188 redirect;
+rewrite ^/law/ej_compilation/2001/2001-18_Admin_Fines_Extension.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=7419 redirect;
 
 # Redirects for /links_files/
 rewrite ^/links_files/Links.shtml /about/ redirect;
@@ -232,6 +234,8 @@ rewrite ^/pages/anreport.shtml /about/reports-about-fec/annual-and-anniversary-r
 rewrite ^/pages/contact.shtml /contact-us/ redirect;
 rewrite ^/pages/record.shtml updates/record-archive-1975-2004/ redirect;
 rewrite ^/pages/statefiling.shtml /introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
+
+# Redirects for /pages/ subdirectories
 rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
 rewrite ^/pages/fecrecord/fecrecord.shtml /updates/?update_type=fec-record redirect;
 rewrite ^/pages/jobs/jobs.shtml /about/careers/ redirect;
@@ -275,7 +279,7 @@ rewrite ^/pdf/2012title2unauthmaterialitythresholdsapprvd5713_redacted.pdf /reso
 rewrite ^/pdf/2012title26materialitythresholdsapprvd12913_redacted.pdf /resources/cms-content/documents/2012_audit_materiality_thresholds_title_26_presidential.pdf redirect;
 rewrite ^/pdf/1997_Enforcement_Manual.pdf /resources/cms-content/documents/1997_enforcement_manual.pdf redirect;
 rewrite ^/pdf/Additional_Enforcement_Materials.pdf /resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
-rewrite ^/pdf/ar1995.pdf https://www.fec.gov/resources/cms-content/documents/ar95.pdf redirect;
+rewrite ^/pdf/ar1995.pdf /resources/cms-content/documents/ar95.pdf redirect;
 rewrite ^/pdf/audit_thresholds_auth_2009-10.pdf /resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_authorized.pdf redirect;
 rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf /resources/cms-content/documents/2009-2010_audit_materiality_thresholds_title_2_unauthorized.pdf redirect;
 rewrite ^/pdf/audit_threshold_title26_2008.pdf /resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
@@ -290,23 +294,23 @@ rewrite ^/pdf/RAD_Procedures_2013-14.pdf /resources/cms-content/documents/2013-2
 rewrite ^/pdf/RAD_Procedures.pdf /resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
 
 # Redirects for /pdf/forms/
-rewrite ^/pdf/forms/fecfrm1auth.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1auth.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1party.pdf /resources/cms-content/documents/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm9i_06.pdf /resources/cms-content/documents/fecform9i.pdf redirect;
-rewrite ^/pdf/forms/fecfrm10i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm10.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm2.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
-rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm5.pdf redirect;
+rewrite ^/pdf/forms/fecfrm10i.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm10.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11i.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12i.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm2cand.pdf /resources/cms-content/documents/fecfrm2.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3x_05.pdf /resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_05.pdf /resources/cms-content/documents/fecfrm3xi.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3x_06.pdf /resources/cms-content/documents/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_06.pdf /resources/cms-content/documents/fecfrm3xi.pdf redirect;
+rewrite ^/pdf/forms/fecfrm5sf.pdf /resources/cms-content/documents/fecfrm5.pdf redirect;
 
 # Redirects for /pdf/record/
 rewrite ^/pdf/record/1996/index96_1.htm /resources/cms-content/documents/index1996.pdf redirect;
@@ -341,37 +345,36 @@ rewrite ^/pubrec/cfsdd/cfsded_000.pdf /resources/cms-content/documents/cfsded.pd
 rewrite ^/rad/documents/FECFileGettingStartedManual.pdf /resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
 
 # Redirects for /resources/about-fec/
-rewrite ^/resources/about-fec/reports/20year.pdf https://www.fec.gov/resources/cms-content/documents/20year.pdf redirect;
-rewrite ^/resources/about-fec/reports/30year.pdf https://www.fec.gov/resources/cms-content/documents/30year.pdf redirect;
-rewrite ^/resources/about-fec/reports/firsttenyearsreport.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
-rewrite ^/resources/about-fec/reports/cbr_app_d.pdf https://www.fec.gov/resources/cms-content/documents/cbr_app_d.pdf redirect;
-rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf https://www.fec.gov/resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
+rewrite ^/resources/about-fec/reports/20year.pdf /resources/cms-content/documents/20year.pdf redirect;
+rewrite ^/resources/about-fec/reports/30year.pdf /resources/cms-content/documents/30year.pdf redirect;
+rewrite ^/resources/about-fec/reports/firsttenyearsreport.pdf /resources/cms-content/documents/firsttenyearsreport.pdf redirect;
+rewrite ^/resources/about-fec/reports/cbr_app_d.pdf /resources/cms-content/documents/cbr_app_d.pdf redirect;
+rewrite ^/resources/about-fec/reports/gifts-to-foreigners-fy2016-letter.pdf /resources/cms-content/documents/gifts-to-foreigners-fy2016-letter.pdf redirect;
 
 # Redirects for /resources/cms-content/documents/
+rewrite ^/resources/about-fec/reports/budget/fy2014/FY2014-SummaryOfPerformanceAndFinancialInformation.pdf /resources/cms-content/documents/FY2014-SummaryOfPerformanceAndFinancialInformation.pdf redirect;
+rewrite ^/resources/about-fec/reports/budget/fy2015/FY2015_AFR.pdf /resources/cms-content/documents/FY2015_AFR.pdf redirect;
+rewrite ^/resources/about-fec/reports/budget/fy2015/FY2015-SummaryOfPerformanceAndFinancialInformation.pdf /resources/cms-content/documents/FY2015-SummaryOfPerformanceAndFinancialInformation.pdf redirect;
+rewrite ^/resources/about-fec/reports/budget/fy2016/FY2016_AFR.pdf /resources/cms-content/documents/FY2016_AFR.pdf redirect;
+rewrite ^/resources/about-fec/reports/budget/fy2016/fy_2016_Congressional_budget.pdf /resources/cms-content/documents/fy_2016_Congressional_budget.pdf redirect;
+rewrite ^/resources/about-fec/reports/budget/fy2017/fy_2017_Congressional_budget.pdf /resources/cms-content/documents/fy_2017_Congressional_budget.pdf redirect;
+rewrite ^/resources/about-fec/reports/ITStrategicPlanFY2016-2020.pdf /resources/cms-content/documents/ITStrategicPlanFY2016-2020.pdf redirect;
+rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf /resources/cms-content/documents/AllPublicFunds.xls redirect;
+rewrite ^/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justificiation.pdf /resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justification.pdf redirect;
+rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf /resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
+rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf /resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
+rewrite ^/resources/cms-content/documents/ie_only_letter.pdf /help-candidates-and-committees/forms/ redirect;
+rewrite ^/resources/cms-content/documents/noncontribution_letter.pdf /help-candidates-and-committees/forms/ redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
 
-rewrite ^/resources/about-fec/reports/budget/fy2014/FY2014-SummaryOfPerformanceAndFinancialInformation.pdf https://www.fec.gov/resources/cms-content/documents/FY2014-SummaryOfPerformanceAndFinancialInformation.pdf redirect;
-rewrite ^/resources/about-fec/reports/budget/fy2015/FY2015_AFR.pdf https://www.fec.gov/resources/cms-content/documents/FY2015_AFR.pdf redirect;
-rewrite ^/resources/about-fec/reports/budget/fy2015/FY2015-SummaryOfPerformanceAndFinancialInformation.pdf https://www.fec.gov/resources/cms-content/documents/FY2015-SummaryOfPerformanceAndFinancialInformation.pdf redirect;
-rewrite ^/resources/about-fec/reports/budget/fy2016/FY2016_AFR.pdf https://www.fec.gov/resources/cms-content/documents/FY2016_AFR.pdf redirect;
-rewrite ^/resources/about-fec/reports/budget/fy2016/fy_2016_Congressional_budget.pdf https://www.fec.gov/resources/cms-content/documents/fy_2016_Congressional_budget.pdf redirect;
-rewrite ^/resources/about-fec/reports/budget/fy2017/fy_2017_Congressional_budget.pdf https://www.fec.gov/resources/cms-content/documents/fy_2017_Congressional_budget.pdf redirect;
-rewrite ^/resources/about-fec/reports/ITStrategicPlanFY2016-2020.pdf https://www.fec.gov/resources/cms-content/documents/ITStrategicPlanFY2016-2020.pdf redirect;
-rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf https://www.fec.gov/resources/cms-content/documents/AllPublicFunds.xls redirect;
-rewrite ^/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justificiation.pdf https://www.fec.gov/resources/cms-content/documents/FEC_FY_2018_Congressional_Budget_Justification.pdf redirect;
-rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_candidates_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Candidates.pdf redirect;
-rewrite ^/resources/cms-content/documents/GettingStarted_FECFileManual_ie_filers_61517.pdf https://www.fec.gov/resources/cms-content/documents/FECFile_GettingStartedManual_Form5Filers.pdf redirect;
-rewrite ^/resources/cms-content/documents/ie_only_letter.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
-rewrite ^/resources/cms-content/documents/noncontribution_letter.pdf https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
-rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf https://www.fec.gov/resources/cms-content/documents/status-of-fec-operations.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/status-of-fec-operations.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf https://www.fec.gov/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
 
 # Redirects for /resources/foia/
 rewrite ^/resources/foia/brgoals.pdf /resources/cms-content/documents/brgoals.pdf redirect;
@@ -394,25 +397,25 @@ rewrite ^/resources/foia/foiareport2007.pdf /resources/cms-content/documents/foi
 rewrite ^/resources/foia/foiareport2006.pdf /resources/cms-content/documents/foiareport2006.pdf redirect;
 
 # Redirects for /resources/legal-resources/enforcement/
-rewrite ^/resources/legal-resources/enforcement/audits/2016/Friends_of_Erik_Paulsen/5OGC-DFAR1357376.pdf https://www.fec.gov/resources/cms-content/documents/5OGC-DFAR1357376.pdf redirect;
+rewrite ^/resources/legal-resources/enforcement/audits/2016/Friends_of_Erik_Paulsen/5OGC-DFAR1357376.pdf /resources/cms-content/documents/5OGC-DFAR1357376.pdf redirect;
 
 # Redirects for /resources/updates/agendas/2011/
-rewrite ^/resources/updates/agendas/2011/mtgdoc_1145.pdf https://www.fec.gov/resources/cms-content/documents/mtgdoc_1145.pdf redirect;
-rewrite ^/resources/updates/agendas/2011/mtgdoc_1145a.pdf https://www.fec.gov/resources/cms-content/documents/mtgdoc_1145a.pdf redirect;
+rewrite ^/resources/updates/agendas/2011/mtgdoc_1145.pdf /resources/cms-content/documents/mtgdoc_1145.pdf redirect;
+rewrite ^/resources/updates/agendas/2011/mtgdoc_1145a.pdf /resources/cms-content/documents/mtgdoc_1145a.pdf redirect;
 
 # This section is for broader redirects
 rewrite ^/auditsearch/(.*) https://www.fec.gov/legal-resources/enforcement/audit-search/ redirect;
-rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
+rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2; 
 rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
 rewrite ^/data/advanced/$ /data/browse-data/ redirect;
 rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;
-rewrite ^/finance/(.*) https://transition.fec.gov/finance/$1 redirect;
+rewrite ^/finance/(.*) https://www.fec.gov/data/ redirect?
 rewrite ^/MUR/(.*) https://www.fec.gov/data/legal/search/enforcement/ redirect;
 rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;
-rewrite ^/rad/(.*) https://transition.fec.gov/rad/$1 redirect;
+rewrite ^/rad/(.*) https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/sunshine/([0-9]+)/(.*).pdf /resources/updates/sunshine-notices/$1/$2.pdf redirect;
 
-#Broader redirects for /agenda/ and subdirectories
+# Broader redirects for /agenda/ and subdirectories
 rewrite ^/agenda/([0-9]+)/documents/(.*) /resources/updates/agendas/$1/$2 redirect;
 rewrite ^/agenda/([0-9]+)/(.*).pdf /resources/updates/agendas/$1/$2.pdf redirect;
 rewrite ^/agenda/agendas2003/(.*).pdf https://www.fec.gov/resources/updates/agendas/2003/$1.pdf redirect;
@@ -420,7 +423,7 @@ rewrite ^/agenda/agendas2002/(.*).pdf https://www.fec.gov/resources/updates/agen
 rewrite ^/agenda/agendas2001/(.*).pdf https://www.fec.gov/resources/updates/agendas/2001/$1.pdf redirect;
 rewrite ^/agenda/agendas2000/(.*).pdf https://www.fec.gov/resources/updates/agendas/2000/$1.pdf redirect;
 
-#Broader redirects for /bulk-downloads/ matching funds
+# Broader redirects for /bulk-downloads/ matching funds
 rewrite ^/files/bulk-downloads/presidential_matching_funds/2008/(.*).zip https://www.fec.gov/resources/cms-content/documents/$1.zip redirect;
 rewrite ^/files/bulk-downloads/presidential_matching_funds/2004/(.*).zip https://www.fec.gov/resources/cms-content/documents/$1.zip redirect;
 
@@ -452,7 +455,7 @@ rewrite ^/info/roundtables/(.*) https://www.fec.gov/help-candidates-and-committe
 rewrite ^/info/state_outreach/(.*) https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;
 
 # Broader redirects for /law/
-rewrite ^/law/cfr/ej_compilation/(.*) https://transition.fec.gov/law/cfr/ej_compilation/$1 redirect;
+rewrite ^/law/cfr/ej_compilation/(.*) https://www.fec.gov/legal-resources/regulations/explanations-and-justifications/ redirect;
 rewrite ^/law/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/law/legislative_recommendations_([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 
@@ -469,8 +472,8 @@ rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;
 rewrite ^/members/(.*).doc /resources/about-fec/commissioners/$1.doc redirect;
 
 # Broader redirects for /pages/ subdirectories
-rewrite ^/pages/brochures/(.*) https://transition.fec.gov/pages/brochures/$1 redirect;
-rewrite ^/pages/report_notices/(.*) http://transition.fec.gov/pages/report_notices/$1 redirect;
+rewrite ^/pages/brochures/(.*) https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/pages/report_notices/(.*) https://www.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 
 # Broader redirects for /pdf/
 rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
@@ -481,7 +484,7 @@ rewrite ^/pdf/record/(.*).pdf /resources/record/$1.pdf redirect;
 
 # Broader redirects for /press/
 rewrite ^/press/press([0-9]+)/(.*) https://www.fec.gov/resources/news_releases/$1/$2 redirect;
-rewrite ^/press/press(.*) http://transition.fec.gov/press/press$1 redirect;
+rewrite ^/press/press(.*) https://www.fec.gov/press/ redirect;
 rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
 
 # Broader redirects for /pubrec/ and subdirectories
@@ -505,7 +508,7 @@ rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/e
 rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/(.*) https://transition.fec.gov/pubrec/$1 redirect;
+rewrite ^/pubrec/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
 
 # Broader redirects for resources/about-fec/
 rewrite ^/resources/about-fec/reports/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -409,7 +409,7 @@ rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2;
 rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
 rewrite ^/data/advanced/$ /data/browse-data/ redirect;
 rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;
-rewrite ^/finance/(.*) https://www.fec.gov/data/ redirect?
+rewrite ^/finance/(.*) https://www.fec.gov/data/ redirect;
 rewrite ^/MUR/(.*) https://www.fec.gov/data/legal/search/enforcement/ redirect;
 rewrite ^/portal/(.*) https://www.fec.gov/data/ redirect;
 rewrite ^/rad/(.*) https://www.fec.gov/help-candidates-and-committees/ redirect;


### PR DESCRIPTION
Updates some redirects from old transition pages to more current CMS pages (note www cleanup tab in [redirect spreadsheet](https://docs.google.com/spreadsheets/d/1vzN-wZlS8K8ZyfExSV3hwXDenDEN9KyyAUJFTI6OjKU/edit#gid=1171400168))

Corrects alphabetical order for some redirects

Takes off the https://www.fec.gov to convert the redirects into relative links (except in the broader ones).

Updates some broader redirects to point to a CMS landing page instead of transition pages.