### PR TITLE
Update redirects-transition.conf

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -935,6 +935,10 @@ rewrite ^/law/policy/enforcement/2009/notice_2009-02.pdf https://www.fec.gov/res
 rewrite ^/law/policy/enforcement/2009/recommendationsummary.pdf https://www.fec.gov/resources/cms-content/documents/recommendations_summary.pdf redirect;
 rewrite ^/law/policy/enforcement/2009/witnesses.pdf https://www.fec.gov/updates/january-14-15-2009-public-hearing-agency-procedures/ redirect;
 rewrite ^/law/policy/enforcement/2009/comments/comments.shtml https://www.fec.gov/legal-resources/policy/comments-received-notice-public-hearing-agency-procedures-and-policies-2009/ redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comm3.pdf https://www.fec.gov/resources/cms-content/documents/commentsotherissues.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comm4.pdf https://www.fec.gov/resources/cms-content/documents/commentsotherissues.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comm5.pdf https://www.fec.gov/resources/cms-content/documents/commentsotherissues.pdf redirect;
+rewrite ^/law/policy/enforcement/2009/comments/comm32.pdf https://www.fec.gov/resources/cms-content/documents/commentsotherissues.pdf redirect;
 
 # law/policy/guidance/ redirects
 rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.doc https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
@@ -942,7 +946,6 @@ rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.
 rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/law/policy/guidance/gb2006-1.pdf https://www.fec.gov/help-candidates-and-committees/purposes-disbursements/ redirect;
 rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
-
 
 # law/policy/internet09/ redirects
 rewrite ^/law/policy/internet09/070609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-6-09websitecomments.pdf redirect;
@@ -1259,6 +1262,7 @@ rewrite ^/pdf/fecfile3.pdf https://www.fec.gov/help-candidates-and-committees/fi
 rewrite ^/pdf/fecxsm.pdf https://www.fec.gov/resources/cms-content/documents/fecxsm.pdf redirect;
 rewrite ^/pdf/firsttenyearsreport.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
 rewrite ^/pdf/firsttenyears.pdf https://www.fec.gov/resources/cms-content/documents/firsttenyearsreport.pdf redirect;
+rewrite ^/pdf/FR66n132p35978.pdf https://www.fec.gov/resources/cms-content/documents/fedreg-notice-2001-09.pdf redirect;
 rewrite ^/pdf/guidesup03.pdf https://www.fec.gov/help-candidates-and-committees/guides/?tab=candidates-and-their-authorized-committees redirect;
 rewrite ^/pdf/hear399.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=63136 redirect;
 rewrite ^/pdf/legrecsup.PDF https://www.fec.gov/resources/cms-content/documents/legrec2000.pdf redirect;


### PR DESCRIPTION
Adds five redirects for transition files.
See 22.1 tab in [redirect spreadsheet](https://docs.google.com/spreadsheets/d/1vzN-wZlS8K8ZyfExSV3hwXDenDEN9KyyAUJFTI6OjKU/).

Note
4 of the files will redirect to https://www.fec.gov/resources/cms-content/documents/commentsotherissues.pdf. That file has to be downloaded in order to open (can't just click the link) but they have been verified to be in there.