### PR TITLE
Update www redirects for Form 7 and for  Form 9 instructions

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -298,7 +298,7 @@ rewrite ^/pdf/forms/fecfrm1auth.pdf /resources/cms-content/documents/policy-guid
 rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1party.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm9i_06.pdf /resources/cms-content/documents/policy-guidance/fecform9i.pdf redirect;
+rewrite ^/pdf/forms/fecfrm9i_06.pdf /resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
 rewrite ^/pdf/forms/fecfrm10i.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect; 
 rewrite ^/pdf/forms/fecfrm10.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
 rewrite ^/pdf/forms/fecfrm11i.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
@@ -395,7 +395,7 @@ rewrite ^/resources/cms-content/documents/fecform7.pdf /resources/cms-content/do
 rewrite ^/resources/cms-content/documents/fecfrm8.pdf /resources/cms-content/documents/policy-guidance/fecfrm8.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm8i.pdf /resources/cms-content/documents/policy-guidance/fecfrm8i.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm9.pdf /resources/cms-content/documents/policy-guidance/fecfrm9.pdf redirect;
-rewrite ^/resources/cms-content/documents/fecform9i.pdf /resources/cms-content/documents/policy-guidance/fecform9i.pdf redirect;
+rewrite ^/resources/cms-content/documents/fecform9i.pdf /resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm13.pdf /resources/cms-content/documents/policy-guidance/fecfrm13.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm13i.pdf /resources/cms-content/documents/policy-guidance/fecfrm13i.pdf redirect;
 rewrite ^/resources/cms-content/documents/fedreg_notice_2009-11.pdf /resources/cms-content/documents/policy-guidance/fedreg_notice_2009-11.pdf redirect;
@@ -441,6 +441,8 @@ rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_ope
 rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
 rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
 
+# Redirects for /resources/cms-content/documents/policy-guidance/
+rewrite ^/resources/cms-content/documents/policy-guidance/fecform9i.pdf /resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
 
 # Redirects for /resources/foia/
 rewrite ^/resources/foia/brgoals.pdf /resources/cms-content/documents/brgoals.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -391,7 +391,7 @@ rewrite ^/resources/cms-content/documents/fecfrm5.pdf /resources/cms-content/doc
 rewrite ^/resources/cms-content/documents/fecfrm5i.pdf /resources/cms-content/documents/policy-guidance/fecfrm5i.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm6.pdf /resources/cms-content/documents/policy-guidance/fecfrm6.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm6i.pdf /resources/cms-content/documents/policy-guidance/fecfrm6i.pdf redirect;
-rewrite ^/resources/cms-content/documents/fecform7.pdf /resources/cms-content/documents/policy-guidance/fecform7.pdf redirect;
+rewrite ^/resources/cms-content/documents/fecform7.pdf /resources/cms-content/documents/policy-guidance/fecfrm7.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm8.pdf /resources/cms-content/documents/policy-guidance/fecfrm8.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm8i.pdf /resources/cms-content/documents/policy-guidance/fecfrm8i.pdf redirect;
 rewrite ^/resources/cms-content/documents/fecfrm9.pdf /resources/cms-content/documents/policy-guidance/fecfrm9.pdf redirect;
@@ -442,6 +442,7 @@ rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_ope
 rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
 
 # Redirects for /resources/cms-content/documents/policy-guidance/
+rewrite ^/resources/cms-content/documents/policy-guidance/fecform7.pdf /resources/cms-content/documents/policy-guidance/fecfrm7.pdf redirect;
 rewrite ^/resources/cms-content/documents/policy-guidance/fecform9i.pdf /resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
 
 # Redirects for /resources/foia/


### PR DESCRIPTION
The filename for Form 9 instructions was changed from 
/fecform9i.pdf to /fecfrm9i.pdf

We are updating older www redirects and adding one from the old name to the new name for the guidance search.