### PR TITLE
Update redirects-transition.conf for new guidance search documents and election results page URLs

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -259,7 +259,7 @@ rewrite ^/em/adr.shtml https://www.fec.gov/legal-resources/enforcement/alternati
 rewrite ^/em/directive_68.pdf https://www.fec.gov/resources/cms-content/documents/directive_68.pdf redirect;
 rewrite ^/em/em.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
 rewrite ^/em/mur.shtml https://www.fec.gov/legal-resources/enforcement/ redirect;
-rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/documents/respondent_guide.pdf redirect;
+rewrite ^/em/respondent_guide.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/respondent_guide.pdf redirect;
 
 # em/enfpro redirects
 rewrite ^/em/enfpro/complistatsfy05-08.pdf https://www.fec.gov/resources/cms-content/documents/complistatsfy05-08.pdf redirect;
@@ -294,7 +294,7 @@ rewrite ^/finance/disclosure/metadata/metadataforcandidatesummary.shtml https://
 rewrite ^/finance/disclosure/presidential_matching_fund_submissions_2004_present.shtml https://www.fec.gov/campaign-finance-data/presidential-matching-fund-submissions/ redirect;
 
 # general/ redirects
-rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/general/FederalElections2016.shtml https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
 rewrite ^/general/library.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
 
 # info/ Info Division redirects
@@ -495,7 +495,7 @@ rewrite ^/law/cfr/ej_compilation/2017/notice2017-03.pdf https://www.fec.gov/docu
 rewrite ^/law/cfr/ej_compilation/2017/notice2017-02.pdf https://www.fec.gov/documents/158/fedreg_notice2017-02.pdf redirect;
 
 # law/cfr/ej_compilation/2016/ redirects
-rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-02_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2016/notice2016-02.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2016-02_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2016/notice2016-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2016-01.pdf redirect;
 
 # law/cfr/ej_compilation/2015/ redirects
@@ -507,10 +507,10 @@ rewrite ^/law/cfr/ej_compilation/2014/notice2014-03.pdf https://www.fec.gov/reso
 rewrite ^/law/cfr/ej_compilation/2014/notice2014-01.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=304204 redirect;
 
 # law/cfr/ej_compilation/2013/ redirects
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-16_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-14_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-16.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-16_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-14.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-14_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2013/notice2013-10.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=298558 redirect;
-rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2013/notice2013-09.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2013-09_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2013/notice2013-03.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2013-03.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2013/78fr46256.pdf https://www.fec.gov/resources/cms-content/documents/cfr-correction_78fr46256.pdf redirect;
 
@@ -519,8 +519,8 @@ rewrite ^/law/cfr/ej_compilation/2012/notice2012-02.pdf https://www.fec.gov/reso
 
 # law/cfr/ej_compilation/2011/ redirects
 rewrite ^/law/cfr/ej_compilation/2011/notice2011-16.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=98733 redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-11_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-13.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2011/notice_2011-11.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2011-11_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2011/notice_2011-02.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-02_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2011-01.pdf redirect;
 
@@ -528,7 +528,7 @@ rewrite ^/law/cfr/ej_compilation/2011/notice_2011-01.pdf https://www.fec.gov/res
 rewrite ^/law/cfr/ej_compilation/2010/notice2010-18.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=21775 redirect;
 rewrite ^/law/cfr/ej_compilation/2010/notice2010-17.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=5395 redirect;
 rewrite ^/law/cfr/ej_compilation/2010/notice2010-14.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=100935 redirect;
-rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2010-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2010/notice_2010-13.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2010-13_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2010/notice_2010-11.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=540 redirect;
 rewrite ^/law/cfr/ej_compilation/2010/notice_2010-10.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=10201 redirect;
 rewrite ^/law/cfr/ej_compilation/2010/notice_2010-08.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=5616 redirect;
@@ -539,7 +539,7 @@ rewrite ^/law/cfr/ej_compilation/2010/notice_2009-32.pdf https://sers.fec.gov/fo
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-27.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=9965 redirect;
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-17.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=6008 redirect;
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-13.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=517 redirect;
-rewrite ^/law/cfr/ej_compilation/2009/notice_2009-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-11.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2009/notice_2009-11.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2009-11.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-09.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=516 redirect;
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-04.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2009-04.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2009/notice_2009-03.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=11860 redirect;
@@ -556,9 +556,9 @@ rewrite ^/law/cfr/ej_compilation/2008/notice_2007-28.pdf https://www.fec.gov/res
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-26.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=4974 redirect;
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-21.pdf https://www.fec.gov/resources/cms-content/documents/notice_2007-21.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-18.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=7700 redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-13_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-09_EO13892.pdf redirect;
-rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2007-08_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-13.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-13_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-9.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-09_EO13892.pdf redirect;
+rewrite ^/law/cfr/ej_compilation/2007/notice_2007-8.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2007-08_EO13892.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-6.pdf https://www.fec.gov/resources/cms-content/documents/notice_2007-6.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-4.pdf https://www.fec.gov/resources/cms-content/documents/notice_2007-4.pdf redirect;
 rewrite ^/law/cfr/ej_compilation/2007/notice_2007-3.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=34789 redirect;
@@ -897,7 +897,7 @@ rewrite ^/law/media/Socialists-Stream.mov https://www.fec.gov/documents/3425/Soc
 
 # law/policy/ redirects
 rewrite ^/law/policy/9413memo_proposedmodificationstoprogram_requestingconsiderationoflegalquestions.pdf https://www.fec.gov/resources/cms-content/documents/9413memo_proposedmodificationstoprogram_requestingconsiderationoflegalquestion.pdf redirect;
-rewrite ^/law/policy/notice_2006-11.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-11_EO13892.pdf redirect;
+rewrite ^/law/policy/notice_2006-11.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2006-11_EO13892.pdf redirect;
 rewrite ^/law/policy/disbursement_purpose.pdf https://www.fec.gov/resources/cms-content/documents/disbursement_purpose.pdf redirect;
 rewrite ^/law/policy/2004/notice2004-03.pdf https://www.fec.gov/resources/cms-content/documents/notice_2004-3.pdf redirect;
 rewrite ^/law/policy/2004/notice2004-20.pdf https://www.fec.gov/resources/cms-content/documents/notice2004-20.pdf redirect;
@@ -941,11 +941,11 @@ rewrite ^/law/policy/enforcement/2009/comments/comm5.pdf https://www.fec.gov/res
 rewrite ^/law/policy/enforcement/2009/comments/comm32.pdf https://www.fec.gov/resources/cms-content/documents/commentsotherissues.pdf redirect;
 
 # law/policy/guidance/ redirects
-rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.doc https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
-rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order.pdf redirect;
-rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/guideline-for-presentation-good-order_appendices.pdf redirect;
+rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.doc https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order.pdf redirect;
+rewrite ^/law/policy/guidance/2008_guideline_approved_aug092007.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order.pdf redirect;
+rewrite ^/law/policy/guidance/Appendices_2008_Guideline.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/guideline-for-presentation-good-order_appendices.pdf redirect;
 rewrite ^/law/policy/guidance/gb2006-1.pdf https://www.fec.gov/help-candidates-and-committees/purposes-disbursements/ redirect;
-rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf redirect;
+rewrite ^/law/policy/guidance/internal_controls_polcmtes_07.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/internal_controls_polcmtes_07_EO13892.pdf redirect;
 
 # law/policy/internet09/ redirects
 rewrite ^/law/policy/internet09/070609websitecomments.pdf https://www.fec.gov/resources/cms-content/documents/7-6-09websitecomments.pdf redirect;
@@ -993,7 +993,7 @@ rewrite ^/law/policy/probablecause/comm04.pdf https://www.fec.gov/resources/cms-
 rewrite ^/law/policy/purposeofdisbursement/comment_cfi.pdf https://www.fec.gov/resources/cms-content/documents/comment_cfi.pdf redirect;
 rewrite ^/law/policy/purposeofdisbursement/comment_crp.pdf https://www.fec.gov/resources/cms-content/documents/comment_crp.pdf redirect;
 rewrite ^/law/policy/purposeofdisbursement/inadequate_purpose_list_3507.pdf https://www.fec.gov/help-candidates-and-committees/purposes-disbursements/ redirect;
-rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-23_EO13892.pdf redirect;
+rewrite ^/law/policy/purposeofdisbursement/notice_2006-23.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2006-23_EO13892.pdf redirect;
 
 # law/policy/suasponte redirects
 rewrite ^/law/policy/suasponte/comm2.pdf https://www.fec.gov/resources/cms-content/documents/suasponte_comm2.pdf redirect;
@@ -1145,7 +1145,7 @@ rewrite ^/pages/brochures/pubfund_limits_2016.shtml https://www.fec.gov/help-can
 rewrite ^/pages/brochures/public_funding_brochure.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/public_funding_brochure2012.pdf https://www.fec.gov/introduction-campaign-finance/understanding-ways-support-federal-candidates/presidential-elections/public-funding-presidential-elections/ redirect;
 rewrite ^/pages/brochures/rad_brochure.pdf https://www.fec.gov/resources/cms-content/documents/RAD_Review_Procedures_Feb2018.pdf redirect;
-rewrite ^/pages/brochures/ReportsAnalysisDivision.shtml https://www.fec.gov/resources/cms-content/documents/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf redirect;
+rewrite ^/pages/brochures/ReportsAnalysisDivision.shtml https://www.fec.gov/resources/cms-content/documents/policy-guidance/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf redirect;
 rewrite ^/pages/brochures/sale_and_use_brochure.pdf https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/saleuse.shtml https://www.fec.gov/updates/sale-or-use-contributor-information/ redirect;
 rewrite ^/pages/brochures/spec_notice_brochure.pdf https://www.fec.gov/help-candidates-and-committees/advertising-and-disclaimers/ redirect;
@@ -1204,30 +1204,33 @@ rewrite ^/pdf/audit_thresholds_unauth_2009-10.pdf https://www.fec.gov/resources/
 rewrite ^/pdf/audit_threshold_title26_2008.pdf https://www.fec.gov/resources/cms-content/documents/2008_audit_materiality_thresholds_title26_presidential.pdf redirect;
 
 # pdf/ Campaign Guide redirects 
-rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/candgui.pdf redirect;
-rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/colagui.pdf redirect;
-rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/partygui.pdf redirect;
-rewrite ^/pdf/nongui.pdf https://www.fec.gov/resources/cms-content/documents/nongui.pdf redirect;
+rewrite ^/pdf/candgui.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/candgui.pdf redirect;
+rewrite ^/pdf/colagui.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/colagui.pdf redirect;
+rewrite ^/pdf/nongui.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/nongui.pdf redirect;
+rewrite ^/pdf/partygui.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/partygui.pdf redirect;
 
 # pdf/forms/ redirects
-rewrite ^/pdf/forms/fecfrm1.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1auth.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm10i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm10.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm2.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3x.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
-rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm3xi.pdf redirect;
-rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/fecfrm5.pdf redirect;
-rewrite ^/pdf/forms/fecfrm9i_06.pdf https://www.fec.gov/resources/cms-content/documents/fecform9i.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1auth.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
+rewrite ^/pdf/forms/fecfrm10.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm10i.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11i.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm2.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3x.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_05.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xi.pdf redirect;
+rewrite ^/pdf/forms/fecfrm3xi_06.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3xi.pdf redirect;
+rewrite ^/pdf/forms/fecfrm5sf.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm5.pdf redirect;
+rewrite ^/pdf/forms/fecform7.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm7.pdf redirect;
+rewrite ^/pdf/forms/fecform9.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm9.pdf redirect;
+rewrite ^/pdf/forms/fecform9i.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
+rewrite ^/pdf/forms/fecfrm9i_06.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
 
 # pdf/ general redirects
 rewrite ^/pdf/00adminfines.pdf https://sers.fec.gov/fosers/showpdf.htm?docid=11146 redirect;
@@ -1238,7 +1241,7 @@ rewrite ^/pdf/2008reports.pdf https://www.fec.gov/updates/reports-due-in-2008/ r
 rewrite ^/pdf/2010reports.pdf https://www.fec.gov/updates/reports-due-in-2010/ redirect;
 rewrite ^/pdf/2011reports.pdf https://www.fec.gov/updates/reports-due-in-2011/ redirect;
 rewrite ^/pdf/441a(d)2006.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2006-03.pdf redirect;
-rewrite ^/pdf/67fr05445.pdf https://www.fec.gov/resources/cms-content/documents/fedreg_notice_2002-01_EO13892.pdf redirect;
+rewrite ^/pdf/67fr05445.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fedreg_notice_2002-01_EO13892.pdf redirect;
 rewrite ^/pdf/Additional_Enforcement_Materials.pdf https://www.fec.gov/resources/cms-content/documents/additional_enforcement_materials.pdf redirect;
 rewrite ^/pdf/ar1995.pdf https://www.fec.gov/resources/cms-content/documents/ar95.pdf redirect;
 rewrite ^/pdf/Audit_Procedures.pdf https://www.fec.gov/legal-resources/enforcement/procedural-materials/ redirect;
@@ -1246,7 +1249,7 @@ rewrite ^/pdf/budget2001.PDF https://www.fec.gov/about/reports-about-fec/strateg
 rewrite ^/pdf/cca.pdf https://www.fec.gov/legal-resources/court-cases/ redirect;
 rewrite ^/pdf/cand_guide_supp.pdf https://www.fec.gov/help-candidates-and-committees/guides/ redirect;
 rewrite ^/pdf/cfr11.pdf https://www.fec.gov/legal-resources/regulations/ redirect;
-rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/documents/commissioners_tips_2016_EO13892.pdf redirect;
+rewrite ^/pdf/commissioners_tips.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/commissioners_tips_2016_EO13892.pdf redirect;
 rewrite ^/pdf/Compliance2000.pdf https://www.fec.gov/help-candidates-and-committees/understanding-public-funding-presidential-elections/receiving-public-funding-grant-for-general-election/ redirect;
 rewrite ^/pdf/corp_guide.pdf https://www.fec.gov/help-candidates-and-committees/guides/?tab=corporations-and-labor-organizations redirect;
 rewrite ^/pdf/corp_supp.pdf https://www.fec.gov/help-candidates-and-committees/guides/?tab=corporations-and-labor-organizations redirect;
@@ -1333,18 +1336,17 @@ rewrite ^/press/bkgnd/presidential_fund.shtml https://www.fec.gov/resources/cms-
 rewrite ^/press/summaries/help/statistical_1975_2010.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics/formula-calculations-statistical-tables-election-cycles-1975-through-2010/ redirect;
 rewrite ^/press/summaries/help/statistical_post2010.shtml https://www.fec.gov/campaign-finance-data/campaign-finance-statistics/formula-calculations-statistical-tables-election-cycles-after-2010/ redirect;
 
-
 # privacy/ redirect
 rewrite ^/privacy.shtml https://www.fec.gov/about/privacy-and-security-policy/ redirect;
 
 # pubrec/ redirects
 rewrite ^/pubrec/2000pres.htm https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/candidates/ redirect;
-rewrite ^/pubrec/2000presgeresults.htm https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/federal-elections-2000/ redirect;
+rewrite ^/pubrec/2000presgeresults.htm https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/federal-elections-2000/ redirect;
 rewrite ^/pubrec/2008pdates.pdf https://www.fec.gov/resources/cms-content/documents/2008pdates.pdf redirect;
 rewrite ^/pubrec/access.htm https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/state-filing-waivers/ redirect;
 rewrite ^/pubrec/alpha.htm https://www.fec.gov/resources/cms-content/documents/1998PDates.pdf redirect;
 rewrite ^/pubrec/chrono.htm https://www.fec.gov/resources/cms-content/documents/1998PDates.pdf redirect;
-rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/electionresults.shtml https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
 rewrite ^/pubrec/faxline.pdf https://www.fec.gov/introduction-campaign-finance/ redirect;
 rewrite ^/pubrec/faxmenu.shtml https://www.fec.gov/introduction-campaign-finance/ redirect;
 rewrite ^/pubrec/prguide1.shtml https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/ redirect;
@@ -1620,7 +1622,7 @@ rewrite ^/pages/report_notices/* https://www.fec.gov/help-candidates-and-committ
 # pdf/ broader redirects
 rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/$1 redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/policy-guidance/documents/$1 redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
 
@@ -1658,26 +1660,26 @@ rewrite ^/press/summaries/party_soft_money/(.*) /resources/campaign-finance-stat
 # /pubrec/ broader redirects
 rewrite ^/pubrec/cfl/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
 rewrite ^/pubrec/cfsdd/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/combined-federalstate-disclosure-and-election-directory/ redirect;
-rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2016/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2014/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2012/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2010/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2008/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2006/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2004/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2002/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe2000/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1996/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1998/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1994/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1992/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1990/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2020/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2018/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2016/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2014/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2012/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2010/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2008/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2006/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2004/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2002/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe2000/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1996/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1998/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1994/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1992/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1990/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1988/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1986/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1984/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
+rewrite ^/pubrec/fe1982/(.*) https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
 rewrite ^/pubrec/pacronyms/(.*) https://www.fec.gov/introduction-campaign-finance/how-to-research-public-records/pacs-parties-and-other-committees/ redirect;
 
 # sunshine/ broader redirects

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -1622,7 +1622,7 @@ rewrite ^/pages/report_notices/* https://www.fec.gov/help-candidates-and-committ
 # pdf/ broader redirects
 rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/policy-guidance/documents/$1 redirect;
+rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/documents/policy-guidance/$1 redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
 

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -50,7 +50,7 @@ rewrite ^/agenda/2010/agenda20100615.shtml https://www.fec.gov/updates/june-16-2
 rewrite ^/agenda/2010/oral_hearing20100120.shtml https://www.fec.gov/updates/oral-hearing-postponed-open-meeting/ redirect;
 
 # agenda/
-rewrite ^/agenda/2009/oral_hearing20091104.shtml https://www.fec.gov/updates/november-4-2009-open-meeting/ redirect;
+rewrite ^/agenda/2009/oral_hearing20091104.shtml https://www.fec.govnovember-4-2009-open-meeting/ redirect;
 
 # ans/ Quick answers redirects
 rewrite ^/ans/agendas.shtml https://www.fec.gov/meetings/ redirect;
@@ -1215,12 +1215,12 @@ rewrite ^/pdf/forms/fecfrm1auth.pdf https://www.fec.gov/resources/cms-content/do
 rewrite ^/pdf/forms/fecfrm1nc.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1party.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
-rewrite ^/pdf/forms/fecfrm10.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm10i.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11i.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm10.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm10i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12i.pdf https://www.fec.gov/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
 rewrite ^/pdf/forms/fecfrm2cand.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm2.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_05.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3x.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_06.pdf https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm3x.pdf redirect;


### PR DESCRIPTION
Updates redirects that pointed to the old URL for the election results page to now point to https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/.

Updates redirects for guidance search documents to include /policy-guidance/ (if a PDF) in their URL. In a few cases, redirects needed to be added.

Full list of the updated and new redirects is in a separate tab of the [redirect spreadsheet](https://docs.google.com/spreadsheets/d/1vzN-wZlS8K8ZyfExSV3hwXDenDEN9KyyAUJFTI6OjKU/edit?usp=sharing) 

Note: Not all of the items on the redirect spreadsheet had a transition redirect to update. Only things that needed an update or a redirect are in this PR.