### PR TITLE
Add www redirects for form 1 and former_members paths

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -294,6 +294,7 @@ rewrite ^/pdf/RAD_Procedures_2013-14.pdf /resources/cms-content/documents/2013-2
 rewrite ^/pdf/RAD_Procedures.pdf /resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
 
 # Redirects for /pdf/forms/
+rewrite ^/pdf/forms/fecfrm1.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect; 
 rewrite ^/pdf/forms/fecfrm1auth.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
@@ -548,7 +549,7 @@ rewrite ^/legal-resources/pdf/record/(.*).pdf https://www.fec.gov/resources/reco
 rewrite ^/legal-resources/court-cases/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
 
 # Broader redirect for /members/former_members/
-rewrite ^/members/former_members/(.*) /resources/about-fec/commissioners/$1 redirect;
+rewrite ^/members/former_members/(.*) /resources/about-fec/commissioners/$1 redirect
 
 # Broader redirects for /members/
 rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -475,7 +475,7 @@ rewrite ^/resources/updates/agendas/2011/mtgdoc_1145a.pdf /resources/cms-content
 
 # Redirects for /updates/
 rewrite ^/updates/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/ /updates/guidance-search/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/ redirect;
-rewrite ^/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ /updates/guidance-search/fec-statement-on-2/ redirect;
+rewrite ^/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ /updates/guidance-search/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ redirect;
 rewrite ^/updates/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/ /updates/guidance-search/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/ redirect;
 rewrite ^/updates/fec-statement-on-carey-fec/ /updates/guidance-search/fec-statement-on-carey-fec/ redirect;
 rewrite ^/updates/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/ /updates/guidance-search/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/ redirect;
@@ -561,7 +561,7 @@ rewrite ^/pages/report_notices/(.*) https://www.fec.gov/help-candidates-and-comm
 
 # Broader redirects for /pdf/
 rewrite ^/pdf/ar([0-9]+) https://www.fec.gov/resources/cms-content/documents/ar$1.pdf redirect;
-rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/policy-guidance/documents/$1 redirect;
+# rewrite ^/pdf/forms/(.*) https://www.fec.gov/resources/cms-content/policy-guidance/documents/$1 redirect;
 rewrite ^/pdf/legrec([0-9]+) https://www.fec.gov/resources/cms-content/documents/legrec$1.pdf redirect;
 rewrite ^/pdf/nprm/(.*) /resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/pdf/record/(.*).pdf /resources/record/$1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -294,6 +294,7 @@ rewrite ^/pdf/RAD_Procedures_2013-14.pdf /resources/cms-content/documents/2013-2
 rewrite ^/pdf/RAD_Procedures.pdf /resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
 
 # Redirects for /pdf/forms/
+rewrite ^/pdf/forms/fecfrm1.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect; 
 rewrite ^/pdf/forms/fecfrm1auth.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -549,7 +549,7 @@ rewrite ^/legal-resources/pdf/record/(.*).pdf https://www.fec.gov/resources/reco
 rewrite ^/legal-resources/court-cases/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
 
 # Broader redirect for /members/former_members/
-rewrite ^/members/former_members/(.*) /resources/about-fec/commissioners/$1 redirect
+rewrite ^/members/former_members/(.*) /resources/about-fec/commissioners/$1 redirect;
 
 # Broader redirects for /members/
 rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -294,7 +294,6 @@ rewrite ^/pdf/RAD_Procedures_2013-14.pdf /resources/cms-content/documents/2013-2
 rewrite ^/pdf/RAD_Procedures.pdf /resources/cms-content/documents/2011-2012_RAD_review_and_referral_procedures.pdf redirect;
 
 # Redirects for /pdf/forms/
-rewrite ^/pdf/forms/fecfrm1.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect; 
 rewrite ^/pdf/forms/fecfrm1auth.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
@@ -547,6 +546,9 @@ rewrite ^/law/litigation/(.*) https://www.fec.gov/legal-resources/court-cases/ r
 # Broader redirects for /legal-resources/
 rewrite ^/legal-resources/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
 rewrite ^/legal-resources/court-cases/pdf/record/(.*).pdf https://www.fec.gov/resources/record/$1.pdf redirect;
+
+# Broader redirect for /members/former_members/
+rewrite ^/members/former_members/(.*) /resources/about-fec/commissioners/$1 redirect;
 
 # Broader redirects for /members/
 rewrite ^/members/(.*).pdf /resources/about-fec/commissioners/$1.pdf redirect;


### PR DESCRIPTION
- Redirects www.fec.gov/pdf/fecfrm1 to its new URL at https://www.fec.gov/resources/cms-content/documents/policy-guidance/fecfrm1.pdf
- Redirects `/members/former_members/...` to `/resources/about-fec/commissioners/....`
    - Resolves [issue #5956](https://github.com/fecgov/fec-cms/issues/5956)
 - Temporarily disable incorrect  redirect for non-existent `policy-guidance/documents`
- Fixes incorrect redirect for `national-party-committee-accounts`:
 ^/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ /updates/guidance-search/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/

 
**How to test:**
- This is deployed to dev
- You can test `fcfrm1` redirect here: https://dev.fec.gov/pdf/forms/fecfrm1.pdf
- You can test the `former_members` redirect by going to http://dev.fec.gov/members/former_members/thomas/thomasarticle08.pdf
Then change `dev` to `www` in the resulting URL to see the PDF. (since these docs are not on dev S3)
- Test that https://dev.fec.gov/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ goes to the correct page (currently goes to Van Hollen page on prod)
