### PR TITLE
Update redirects-www.conf

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -150,7 +150,7 @@ rewrite ^/info/publications.shtml /help-candidates-and-committees/guides/ redire
 rewrite ^/info/report_dates_2017.shtml /help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/roundtable_materials/workshopmaterials.shtml help-candidates-and-committees/trainings/ redirect;
 rewrite ^/info/TimelyTipsArchive.shtml /updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TimelyTipsArchive2006.shtml/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml /updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/TipsforTreasurers.shtml /updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/toolkit.shtml /help-candidates-and-committees/ redirect;
 

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -118,7 +118,7 @@ rewrite ^/finance/disclosure/candcmte_info.shtml /data/ redirect;
 # Redirects for /general/
 rewrite ^/general/library.shtml /introduction-campaign-finance/how-to-research-public-records/ redirect;
 rewrite ^/general/FederalElections2016.shtml /introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/general/whatsnew.shtml /updates/ redirect;
+rewrite ^/general/whatsnew.shtml  redirect;
 
 # Redirects for /images/ 
 rewrite ^/images/transcript_icon.png /resources/cms-content/images/classic_transcript_icon.original.png redirect;
@@ -149,9 +149,9 @@ rewrite ^/info/outreach.shtml /help-candidates-and-committees/trainings/ redirec
 rewrite ^/info/publications.shtml /help-candidates-and-committees/guides/ redirect;
 rewrite ^/info/report_dates_2017.shtml /help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/roundtable_materials/workshopmaterials.shtml help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/TimelyTipsArchive.shtml /updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TimelyTipsArchive2006.shtml /updates/?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TipsforTreasurers.shtml /updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive.shtml ?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml ?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TipsforTreasurers.shtml ?update_type=tips-for-treasurers redirect;
 rewrite ^/info/toolkit.shtml /help-candidates-and-committees/ redirect;
 
 # Redirects for /info/guidance/
@@ -237,7 +237,7 @@ rewrite ^/pages/statefiling.shtml /introduction-campaign-finance/how-to-research
 
 # Redirects for /pages/ subdirectories
 rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
-rewrite ^/pages/fecrecord/fecrecord.shtml /updates/?update_type=fec-record redirect;
+rewrite ^/pages/fecrecord/fecrecord.shtml ?update_type=fec-record redirect;
 rewrite ^/pages/jobs/jobs.shtml /about/careers/ redirect;
 rewrite ^/pages/procure/procure.shtml /about/reports-about-fec/procurement-and-contracting/ redirect;
 
@@ -300,12 +300,12 @@ rewrite ^/pdf/forms/fecfrm1ssf.pdf /resources/cms-content/documents/policy-guida
 rewrite ^/pdf/forms/fecfrm1nc.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm1party.pdf /resources/cms-content/documents/policy-guidance/fecfrm1.pdf redirect;
 rewrite ^/pdf/forms/fecfrm9i_06.pdf /resources/cms-content/documents/policy-guidance/fecfrm9i.pdf redirect;
-rewrite ^/pdf/forms/fecfrm10i.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect; 
-rewrite ^/pdf/forms/fecfrm10.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11i.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm11.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12i.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/pdf/forms/fecfrm12.pdf /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm10i.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect; 
+rewrite ^/pdf/forms/fecfrm10.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11i.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm11.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12i.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
+rewrite ^/pdf/forms/fecfrm12.pdf /updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
 rewrite ^/pdf/forms/fecfrm2cand.pdf /resources/cms-content/documents/policy-guidance/fecfrm2.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3x_05.pdf /resources/cms-content/documents/policy-guidance/fecfrm3x.pdf redirect;
 rewrite ^/pdf/forms/fecfrm3xi_05.pdf /resources/cms-content/documents/policy-guidance/fecfrm3xi.pdf redirect;
@@ -473,20 +473,9 @@ rewrite ^/resources/legal-resources/enforcement/audits/2016/Friends_of_Erik_Paul
 rewrite ^/resources/updates/agendas/2011/mtgdoc_1145.pdf /resources/cms-content/documents/mtgdoc_1145.pdf redirect;
 rewrite ^/resources/updates/agendas/2011/mtgdoc_1145a.pdf /resources/cms-content/documents/mtgdoc_1145a.pdf redirect;
 
-# Redirects for /updates/
-rewrite ^/updates/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/ /updates/guidance-search/fec-adopts-interim-verification-procedure-for-filings-containing-possibly-false-or-fictitious-information/ redirect;
-rewrite ^/updates/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ /updates/guidance-search/fec-issues-interim-reporting-guidance-for-national-party-committee-accounts/ redirect;
-rewrite ^/updates/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/ /updates/guidance-search/fec-provides-guidance-following-us-district-court-decision-crew-v-fec-316-f-supp-3d-349-ddc-2018/ redirect;
-rewrite ^/updates/fec-statement-on-carey-fec/ /updates/guidance-search/fec-statement-on-carey-fec/ redirect;
-rewrite ^/updates/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/ /updates/guidance-search/fec-statement-on-the-dc-circuit-court-of-appeals-decision-in/ redirect;
-rewrite ^/updates/fec-statement-on-2/ /updates/guidance-search/fec-statement-on-2/ redirect;
-rewrite ^/updates/fec-statement-on-the-supreme-courts-decision-in/ /updates/guidance-search/fec-statement-on-the-supreme-courts-decision-in/ redirect;
-rewrite ^/updates/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ /updates/guidance-search/federal-election-commissions-public-statement-on-the-supreme-courts-decision-in/ redirect;
-
-
 # This section is for broader redirects
 rewrite ^/auditsearch/(.*) https://www.fec.gov/legal-resources/enforcement/audit-search/ redirect;
-rewrite ^/audits/([0-9]+)/(.*) https://transition.fec.gov/audits/$1/$2; 
+rewrite ^/audits/([0-9]+)/(.*) https://www.fec.gov/resources/legal-resources/enforcement/audits/$1/$2 redirect; 
 rewrite ^/audio/([0-9]+)/(.*) /resources/audio/$1/$2 redirect;
 rewrite ^/data/advanced/$ /data/browse-data/ redirect;
 rewrite ^/fecletter/(.*) https://www.fec.gov/data/filings/?data_type=processed&form_type=RFAI redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -118,7 +118,7 @@ rewrite ^/finance/disclosure/candcmte_info.shtml /data/ redirect;
 # Redirects for /general/
 rewrite ^/general/library.shtml /introduction-campaign-finance/how-to-research-public-records/ redirect;
 rewrite ^/general/FederalElections2016.shtml /introduction-campaign-finance/election-and-voting-information/ redirect;
-rewrite ^/general/whatsnew.shtml  redirect;
+rewrite ^/general/whatsnew.shtml /updates/ redirect;
 
 # Redirects for /images/ 
 rewrite ^/images/transcript_icon.png /resources/cms-content/images/classic_transcript_icon.original.png redirect;
@@ -149,9 +149,9 @@ rewrite ^/info/outreach.shtml /help-candidates-and-committees/trainings/ redirec
 rewrite ^/info/publications.shtml /help-candidates-and-committees/guides/ redirect;
 rewrite ^/info/report_dates_2017.shtml /help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/info/roundtable_materials/workshopmaterials.shtml help-candidates-and-committees/trainings/ redirect;
-rewrite ^/info/TimelyTipsArchive.shtml ?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TimelyTipsArchive2006.shtml ?update_type=tips-for-treasurers redirect;
-rewrite ^/info/TipsforTreasurers.shtml ?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive.shtml /updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TimelyTipsArchive2006.shtml/updates/?update_type=tips-for-treasurers redirect;
+rewrite ^/info/TipsforTreasurers.shtml /updates/?update_type=tips-for-treasurers redirect;
 rewrite ^/info/toolkit.shtml /help-candidates-and-committees/ redirect;
 
 # Redirects for /info/guidance/
@@ -237,7 +237,7 @@ rewrite ^/pages/statefiling.shtml /introduction-campaign-finance/how-to-research
 
 # Redirects for /pages/ subdirectories
 rewrite ^/pages/budget/budget.shtml /about/reports-about-fec/strategy-budget-and-performance/ redirect;
-rewrite ^/pages/fecrecord/fecrecord.shtml ?update_type=fec-record redirect;
+rewrite ^/pages/fecrecord/fecrecord.shtml /updates/?update_type=fec-record redirect;
 rewrite ^/pages/jobs/jobs.shtml /about/careers/ redirect;
 rewrite ^/pages/procure/procure.shtml /about/reports-about-fec/procurement-and-contracting/ redirect;
 


### PR DESCRIPTION
This PR
- Removes redirects to alias'ed press release pages
- Updates broader redirect that was pointing to an old transition folder 

To test - no redirects should be pointing to /updates/guidance-search/ URLs.