### PR TITLE
Update redirects-transition.conf

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -321,7 +321,7 @@ rewrite ^/info/contriblimitschart1314.pdf https://www.fec.gov/help-candidates-an
 rewrite ^/info/efnprm.htm https://sers.fec.gov/fosers/showpdf.htm?docid=62698 redirect;
 rewrite ^/info/elearning.shtml https://www.fec.gov/help-candidates-and-committees/trainings/#e-learning-videos redirect;
 rewrite ^/info/elecmas.htm https://www.fec.gov/help-candidates-and-committees/filing-reports/other-filing-software/ redirect;
-rewrite ^/info/election_day_links.shtml https://www.fec.gov/introduction-campaign-finance/election-day-information/ redirect;
+rewrite ^/info/election_day_links.shtml https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/ redirect;
 rewrite ^/info/filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
 rewrite ^/info/fecmaill.shtml https://public.govdelivery.com/accounts/USFEC/subscriber/new?qsp=CODE_RED redirect;
 rewrite ^/info/FECWebinars.shtml https://www.fec.gov/help-candidates-and-committees/trainings/ redirect;


### PR DESCRIPTION
Updated redirect from https://www.fec.gov/introduction-campaign-finance/election-day-information/ to https://www.fec.gov/introduction-campaign-finance/election-results-and-voting-information/