### PR TITLE
Update redirects-e-regs.conf for 2023

### DIFF
--- a/redirects-e-regs.conf
+++ b/redirects-e-regs.conf
@@ -10,6 +10,11 @@ rewrite ^/regulations/111-44/2021-annual-111 https://www.ecfr.gov/cgi-bin/text-i
 rewrite ^/regulations/111-24/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
 rewrite ^/regulations/111-43/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
 rewrite ^/regulations/111-44/2022-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;
-rewrite ^/regulations/partial/111-24/2022-annual-111 https://transition.fec.gov/regulations/page-ref-111-24.html redirect;
-rewrite ^/regulations/partial/111-43/2022-annual-111 https://transition.fec.gov/regulations/page-ref-111-43.html redirect;
-rewrite ^/regulations/partial/111-44/2022-annual-111 https://transition.fec.gov/regulations/page-ref-111-44.html redirect;
+rewrite ^/regulations/100-26/2023-annual-100 https://www.ecfr.gov/current/title-11/chapter-I/subchapter-A/part-100/subpart-A/section-100.26 redirect;
+rewrite ^/regulations/111-24/2023-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_124 redirect;
+rewrite ^/regulations/111-43/2023-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_143 redirect;
+rewrite ^/regulations/111-44/2023-annual-111 https://www.ecfr.gov/cgi-bin/text-idx?node=se11.1.111_144 redirect;
+rewrite ^/regulations/partial/100-26/2023-annual-100 https://transition.fec.gov/regulations/page-ref-100-26.html redirect;
+rewrite ^/regulations/partial/111-24/2023-annual-111 https://transition.fec.gov/regulations/page-ref-111-24.html redirect;
+rewrite ^/regulations/partial/111-43/2023-annual-111 https://transition.fec.gov/regulations/page-ref-111-43.html redirect;
+rewrite ^/regulations/partial/111-44/2023-annual-111 https://transition.fec.gov/regulations/page-ref-111-44.html redirect;


### PR DESCRIPTION
Updates redirects per issues #391 and #392 

You can review the updated partials here (please ignore the funny Â characters, it's because we pull in the partials into the regulations site and it will be styled navigating to it there.):

- https://transition.fec.gov/regulations/page-ref-100-26.html
- https://transition.fec.gov/regulations/page-ref-111-24.html
- https://transition.fec.gov/regulations/page-ref-111-43.html
- https://transition.fec.gov/regulations/page-ref-111-44.html