### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] Add test-eqs.fec.gov as a domain route and eqs redirects file

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 700M
     routes:
       - route: dev.fec.gov
+      - route: test-eqs.fec.gov
     stack: cflinuxfs4
     buildpacks:
       - nginx_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -8,6 +8,7 @@ applications:
       - route: beta.fec.gov
       - route: transition.fec.gov
       - route: www.fec.gov
+      - route: eqs.fec.gov
     stack: cflinuxfs4
     buildpacks:
       - nginx_buildpack

--- a/nginx.conf
+++ b/nginx.conf
@@ -93,4 +93,10 @@ http {
       add_header X-Frame-Options "SAMEORIGIN";
     }
   }
+
+  server {
+    listen {{port}};
+    server_name test-eqs.fec.gov;
+    include redirects-eqs.conf;
+  }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -99,4 +99,10 @@ http {
     server_name test-eqs.fec.gov;
     include redirects-eqs.conf;
   }
+
+  server {
+    listen {{port}};
+    server_name eqs.fec.gov;
+    include redirects-eqs.conf;
+  }
 }

--- a/redirects-eqs.conf
+++ b/redirects-eqs.conf
@@ -1,0 +1,5 @@
+rewrite ^/eqsdocsMUR/(\d+)_(\d+)\.pdf$ https://www.fec.gov/files/legal/murs/$1/$1_$2.pdf redirect;
+rewrite ^/eqsdocsADR/(\d+)_(\d+)\.pdf$ https://www.fec.gov/files/legal/adrs/$1/$1_$2.pdf redirect;
+rewrite ^/eqsdocsAF/(\d+)_(\d+)\.pdf$ https://www.fec.gov/files/legal/admin_fines/$1/$1_$2.pdf redirect;
+rewrite ^/eqs/searcheqs https://www.fec.gov/legal-resources/enforcement/ redirect;
+rewrite ^/ https://www.fec.gov/legal-resources/enforcement/ redirect;


### PR DESCRIPTION
Redirects for test-eqs.fec.gov domain. Test redirect URLs:

https://test-eqs.fec.gov/eqsdocsMUR/8017_15.pdf
https://test-eqs.fec.gov/eqsdocsADR/1152_07.pdf
https://test-eqs.fec.gov/eqsdocsAF/4632_01.pdf
https://test-eqs.fec.gov/eqs/searcheqs
https://test-eqs.fec.gov/