### PR TITLE
Update redirects-www.conf for COVID plan

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -434,15 +434,15 @@ rewrite ^/resources/cms-content/documents/RAD_FAQs-PACs_last_visited_september_2
 rewrite ^/resources/cms-content/documents/RAD_FAQ-Party_Committees_last_visited_may_5_2021.pdf /resources/cms-content/documents/policy-guidance/RAD_FAQ-Party_Committees_last_visited_may_5_2021.pdf redirect;
 rewrite ^/resources/cms-content/documents/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf /resources/cms-content/documents/policy-guidance/RAD_FAQ-RAD_Processes_last_visited_may_5_2021.pdf redirect;
 rewrite ^/resources/cms-content/documents/respondent_guide.pdf /resources/cms-content/documents/policy-guidance/respondent_guide.pdf redirect;
-rewrite ^/resources/cms-content/documents/status-of-fec-operations.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
-rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf /resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/status-of-fec-operations-1-4-2021.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-4-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/status_of_fec_operations_8-10-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_FEC_operations_3-17-20.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_operations_3-24-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
 
 # Redirects for /resources/cms-content/documents/policy-guidance/
 rewrite ^/resources/cms-content/documents/policy-guidance/fecform7.pdf /resources/cms-content/documents/policy-guidance/fecfrm7.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -443,6 +443,7 @@ rewrite ^/resources/cms-content/documents/website-notice_regarding_status_of_ope
 rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_3-26-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
 rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_6-5-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
 rewrite ^/resources/cms-content/documents/website_notice_regarding_status_of_operations_phase_1_6-17-2020.pdf /about/reports-about-fec/agency-operations/ redirect;
+rewrite ^/resources/cms-content/documents/FEC-COVID-19-workplace-safety-plan.pdf /about/reports-about-fec/agency-operations/ redirect;
 
 # Redirects for /resources/cms-content/documents/policy-guidance/
 rewrite ^/resources/cms-content/documents/policy-guidance/fecform7.pdf /resources/cms-content/documents/policy-guidance/fecfrm7.pdf redirect;


### PR DESCRIPTION
Need all COVID plans to redirect to /about/reports-about-fec/agency-operations/