### PR TITLE
remove eregs app from proxy

### DIFF
--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -61,4 +61,3 @@ cf ${command} ${app} -f ${manifest}
 
 # Add network policies
 cf add-network-policy proxy cms
-cf add-network-policy proxy eregs

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -14,6 +14,5 @@ applications:
       - fec-creds-dev
     env:
       CMS_PROXY: "http://fec-dev-cms.apps.internal:8080"
-      EREGS_PROXY: "http://fec-dev-eregs.apps.internal:8080"
       S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"
       S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -16,7 +16,6 @@ applications:
       - fec-creds-prod
     env:
       CMS_PROXY: "http://fec-prod-cms.apps.internal:8080"
-      EREGS_PROXY: "http://fec-prod-eregs.apps.internal:8080"
       S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"
       S3_TRANSITION_URL: "http://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
       S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -13,6 +13,5 @@ applications:
       - fec-creds-stage
     env:
       CMS_PROXY: "http://fec-stage-cms.apps.internal:8080"
-      EREGS_PROXY: "http://fec-stage-eregs.apps.internal:8080"
       S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"
       S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-d3527d7d-0344-45b5-aab6-5a39d2aa409f.s3-us-gov-west-1.amazonaws.com"

--- a/nginx.conf
+++ b/nginx.conf
@@ -50,15 +50,6 @@ http {
       proxy_set_header X-Script-Name "/";
     }
 
-    location /regulations {
-      resolver {{nameservers}} ipv6=off valid=1s;
-      set $backend "{{env "EREGS_PROXY"}}";
-      proxy_pass $backend;
-      proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Script-Name "/regulations";
-    }
-
     location ~ /resources/(.*) {
       resolver 8.8.8.8;
       proxy_pass_request_headers off;


### PR DESCRIPTION
Removes the eregs app from proxy as it was shut down recently. 