### PR TITLE
[MERGE WITH GITFLOW - HOTFIX] Remove `/efiling` redirect

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -2,7 +2,6 @@
 
 # Redirects for main directory
 rewrite ^/about.shtml /about/ redirect;
-rewrite ^/efiling /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/fosers/ http://sers.fec.gov/fosers/ redirect;
 rewrite ^/pindex.shtml /data/ redirect;
 rewrite ^/pki https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com/bulk-downloads/index.html?prefix=bulk-downloads/PKI/ redirect;


### PR DESCRIPTION
The `/efiling` redirect is overriding the redirects that we want to make using the CMS. Therefore, we are removing it from the proxy and handling that specific redirect using the CMS instead.

This has been deployed to stage for testing.

- Go to https://stage.fec.gov/efiling/ and it should redirect to https://stage.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/

- Go to https://stage.fec.gov/efiling/getting-started-fecfile-pilot/ and it should redirect to https://stage.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/getting-started-with-the-fecfile-pilot/