### PR TITLE
upgrade cf cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=8.9.0" | tar xzv -C $HOME/bin
 
       - run:
           name: Deploy Proxy

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The proxy follows [other projects](https://github.com/fecgov/openFEC#creating-a-
 
 Manual deployment is an option if there are issues with CircleCI or you want more granular control of the process.
 
-Before you start, make sure you have version 7 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
+Before you start, make sure you have version 8 of the [Cloud Foundry CLI](https://docs.cloudfoundry.org/devguide/cf-cli/install-go-cli.html) installed.
 
 When you're ready to deploy any changes, make sure you are on the `master` branch and have done a `git pull` so that all changes are pulled down.  Now run the following commands, where `<space>` is the desired space you'd like to deploy to (`dev`, `stage`, or `prod`):
 


### PR DESCRIPTION
## Summary 
The Cloud.gov v2 API for Cloud Foundry is reaching its end-of-life. CF CLI versions 6 and 7 still rely on Cloud Foundry API v2 and will no longer work in coming months with foundations that have disabled it. However, CF CLI v8 no longer uses Cloud Foundry API v2. For more details, refer to this [link](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md#impact-and-consequences).

1. circleci/config.yml, is upgraded to CF CLI v8.9.0. This version supports Cloud Foundry API v3. Deploying to a cloud.gov space should work smoothly with this update

## Resolves # https://github.com/fecgov/openFEC/issues/6110

### Required reviewers

1 developer

## Impacted areas of the application

- install cf cli script
- deploy proxy (to cloud.gov space)


## Screenshots
**Before:**
[cf cli v7.0.1 circleci build](https://app.circleci.com/pipelines/github/fecgov/fec-proxy/577/workflows/4065a32d-7eff-40cf-b0a9-ef9fb0f75aff/jobs/620):

<img width="1134" alt="Screenshot 2025-01-29 at 4 27 03 PM" src="https://github.com/user-attachments/assets/ff782daa-1f14-4603-a4bc-1b49d7ff3423" />


**After:**
[cf cli v8.9.0. circleci build](https://app.circleci.com/pipelines/github/fecgov/fec-proxy/580/workflows/a61e1faa-5736-43d2-90fd-a7516c15ed6e/jobs/622):

<img width="1142" alt="Screenshot 2025-01-29 at 4 27 52 PM" src="https://github.com/user-attachments/assets/cd237d6e-a75c-4ddb-b71f-b3c3fd966d23" />

## Related PRs


Related PRs against other branches:

- openFEC: https://github.com/fecgov/openFEC/pull/6114
- fec-cms: https://github.com/fecgov/fec-cms/pull/6657
- fec-proxy-redirect: https://github.com/fecgov/fec-proxy-redirect/pull/20
- fec-pattern-library: https://github.com/fecgov/fec-pattern-library/pull/229

## How to test
 
- Follow [these](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) instructions to install cf CLI v8 on your local terminal or  run: `brew install cloudfoundry/tap/cf-cli@8`
- verify cf cli version: run `cf version`

```
F612211M:~ pkasireddy$ cf version
cf version 8.9.0+c23186c.2024-12-02
```
- login to cloud.gov dev space. use the [manual deployment steps](https://github.com/fecgov/fec-proxy-redirect?tab=readme-ov-file#manual-deployment) to deploy this app from terminal

- Observe the following in terminal: 
- 1. Confirm that fec-proxy app  is using [Cloud Foundry v3 API](https://v3-apidocs.cloudfoundry.org/version/3.185.0/):

```
API endpoint:   https://api.fr.cloud.gov
API version:    3.185.0
```
