### PR TITLE
[HOTFIX - MERGE WITH GITFLOW] EEO redirects

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -361,6 +361,9 @@ rewrite ^/resources/about-fec/reports/budget/fy2016/FY2016_AFR.pdf /resources/cm
 rewrite ^/resources/about-fec/reports/budget/fy2016/fy_2016_Congressional_budget.pdf /resources/cms-content/documents/fy_2016_Congressional_budget.pdf redirect;
 rewrite ^/resources/about-fec/reports/budget/fy2017/fy_2017_Congressional_budget.pdf /resources/cms-content/documents/fy_2017_Congressional_budget.pdf redirect;
 rewrite ^/resources/about-fec/reports/ITStrategicPlanFY2016-2020.pdf /resources/cms-content/documents/ITStrategicPlanFY2016-2020.pdf redirect;
+rewrite ^/resources/cms-content/documents/2023-MD715-Report-May-2024.pdf /about/equal-employment-opportunity/ redirect;
+rewrite ^/resources/cms-content/documents/2023_No_FEAR_Act_Report.pdf /about/equal-employment-opportunity/ redirect;
+rewrite ^/resources/cms-content/documents/2024-Federal-Election-Commission-EEO-Policy-Statement-Chairman-Cooksey.pdf /about/equal-employment-opportunity/ redirect;
 rewrite ^/resources/cms-content/documents/AllPublicFunds.pdf /resources/cms-content/documents/AllPublicFunds.xls redirect; 
 rewrite ^/resources/cms-content/documents/candgui.pdf /resources/cms-content/documents/policy-guidance/candgui.pdf redirect;
 rewrite ^/resources/cms-content/documents/colagui.pdf /resources/cms-content/documents/policy-guidance/colagui.pdf redirect;
@@ -423,6 +426,7 @@ rewrite ^/resources/cms-content/documents/guideline-for-presentation-good-order_
 rewrite ^/resources/cms-content/documents/ie_only_letter.pdf /help-candidates-and-committees/forms/ redirect;
 rewrite ^/resources/cms-content/documents/internal_controls_polcmtes_07_EO13892.pdf /resources/cms-content/documents/policy-guidance/internal_controls_polcmtes_07_EO13892.pdf redirect;
 rewrite ^/resources/cms-content/documents/noncontribution_letter.pdf /help-candidates-and-committees/forms/ redirect;
+rewrite ^/resources/cms-content/documents/No-FEAR-Notice-2024.pdf /about/equal-employment-opportunity/ redirect;
 rewrite ^/resources/cms-content/documents/nongui.pdf /resources/cms-content/documents/policy-guidance/nongui.pdf redirect;
 rewrite ^/resources/cms-content/documents/partygui.pdf /resources/cms-content/documents/policy-guidance/partygui.pdf redirect;
 rewrite ^/resources/cms-content/documents/RAD_FAQ-Candidate_Committees_last_visited_may_5_2021.pdf /resources/cms-content/documents/policy-guidance/RAD_FAQ-Candidate_Committees_last_visited_may_5_2021.pdf redirect;


### PR DESCRIPTION
Replaces PR https://github.com/fecgov/fec-proxy/pull/417 in order to create as hotfix

Redirects the following removed EEO office documents to https://www.fec.gov/about/equal-employment-opportunity/

- /resources/cms-content/documents/2024-Federal-Election-Commission-EEO-Policy-Statement-Chairman-Cooksey.pdf

- /resources/cms-content/documents/No-FEAR-Notice-2024.pdf

- /resources/cms-content/documents/2023_No_FEAR_Act_Report.pdf

- /resources/cms-content/documents/2023-MD715-Report-May-2024.pdf