### PR TITLE
Add redirects for new SAOS domain

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -96,4 +96,10 @@ http {
     server_name eqs.fec.gov;
     include redirects-eqs.conf;
   }
+
+  server {
+    listen {{port}};
+    server_name saos.fec.gov;
+    include redirects-saos.conf;
+  }
 }

--- a/redirects-saos.conf
+++ b/redirects-saos.conf
@@ -1,0 +1,3 @@
+rewrite "^/aodocs/((\d{4})(\d{2}).+\.pdf)$" https://www.fec.gov/files/legal/aos/$2-$3/$1 redirect;
+rewrite ^/saos/searchao https://www.fec.gov/data/legal/advisory-opinions/ redirect;
+rewrite ^/ https://www.fec.gov/data/legal/advisory-opinions/ redirect;


### PR DESCRIPTION
Adding initial redirects for SAOS domain. I expect to have the domain delegated soon. In order to test this, you can use the test-eqs.fec.gov route and point the redirects file redirects-saos.conf.

Test these redirects based on this [spreadsheet](https://docs.google.com/spreadsheets/d/1BiVD3E6RWPNDt1PhlhAxZMwCWO-XOI7MKOnXJJuVEso/edit?gid=1588408748#gid=1588408748) 🔒 

