### PR TITLE
Retire and redirect transition.fec.gov and

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -18,5 +18,4 @@ applications:
     env:
       CMS_PROXY: "http://fec-prod-cms.apps.internal:8080"
       S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"
-      S3_TRANSITION_URL: "http://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
       S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com"

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,13 +75,7 @@ http {
     server_name transition.fec.gov;
     include redirects-transition.conf;
     location / {
-      resolver 8.8.8.8;
-      error_page 404 error.html;
-      proxy_hide_header      x-amz-id-2;
-      proxy_hide_header      x-amz-request-id;
-      proxy_hide_header      x-amz-meta-s3cmd-attrs;
-      proxy_pass {{env "S3_TRANSITION_URL"}}$uri;
-      add_header X-Frame-Options "SAMEORIGIN";
+      rewrite ^/(.*)$ https://www.fec.gov/$1 redirect;
     }
   }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,7 +75,7 @@ http {
     server_name transition.fec.gov;
     include redirects-transition.conf;
     location / {
-      rewrite ^/(.*)$ https://www.fec.gov/$1 redirect;
+      rewrite ^/(.*)$ https://www.fec.gov/$1 permanent;
     }
   }
 


### PR DESCRIPTION
### Summary

Resolves https://github.com/fecgov/fec-cms/issues/6856

Remove s3 bucket and add temporary redirect for transition site

Required reviewers: 1 engineer
