### PR TITLE
Redirect FEC accommodations policy

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -14,6 +14,7 @@ rewrite ^/working.shtml /about/#working-with-the-fec redirect;
 rewrite ^/about/offices/EEO/EEO.shtml /about/equal-employment-opportunity/ redirect;
 rewrite ^/about/offices/offices.shtml /about/leadership-and-structure/fec-offices/ redirect; 
 rewrite ^/about/offices/org_chart.shtml /about/leadership-and-structure/fec-offices/ redirect;
+rewrite ^/resources/cms-content/documents/Accommodation_Policy_for_FEC_5-2025_FECweb.pdf /resources/cms-content/documents/Accommodation-Policy-for-FEC-employees.pdf redirect;
 
 # Redircts for /af/
 rewrite ^/af/index.shtml /legal-resources/enforcement/administrative-fines/ redirect;


### PR DESCRIPTION
Some clean up work since we have duplicate copies of the same document. We need to redirect the FEC accommodations policy PDF from https://www.fec.gov/resources/cms-content/documents/Accommodation_Policy_for_FEC_5-2025_FECweb.pdf to https://www.fec.gov/resources/cms-content/documents/Accommodation-Policy-for-FEC-employees.pdf. Once this change is made, the duplicate copy, Accommodation_Policy_for_FEC_5-2025_FECweb.pdf, will be deleted from the CMS.