### PR TITLE
[HOTFIX - merge with gitflow] Configure Nginx rate limiting for selected client IPs and selected route paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Staticfile.auth
+blockips.conf
+ratelimitedips.conf
+ratelimitedroutes.conf

--- a/generate_blockips.sh
+++ b/generate_blockips.sh
@@ -17,6 +17,16 @@ BLOCKED_IPS=$(echo "$VCAP_SERVICES" | jq -r '
   | select(.credentials.BLOCKED_IPS != null) 
   | .credentials.BLOCKED_IPS' | head -n 1)
 
+RATE_LIMITED_IPS=$(echo "$VCAP_SERVICES" | jq -r '
+  .["user-provided"][]?
+  | select(.credentials.RATE_LIMITED_IPS != null)
+  | .credentials.RATE_LIMITED_IPS' | head -n 1)
+
+RATE_LIMITED_ROUTES=$(echo "$VCAP_SERVICES" | jq -r '
+  .["user-provided"][]?
+  | select(.credentials.RATE_LIMITED_ROUTES != null)
+  | .credentials.RATE_LIMITED_ROUTES' | head -n 1)
+
 if [[ -z "$BLOCKED_IPS" || "$BLOCKED_IPS" == "null" ]]; then
   echo "No BLOCKED_IPS set in cloud.gov for app '${app}', skipping blockips.conf generation"
   echo "# No blocked IPs configured" > blockips.conf
@@ -24,9 +34,37 @@ else
   echo "# Auto-generated list of blocked IPs" > blockips.conf
   IFS=',' read -ra IPS <<< "$BLOCKED_IPS"
   for ip in "${IPS[@]}"; do
+    ip=$(echo "$ip" | xargs)
+    [[ -z "$ip" ]] && continue
     escaped_ip=$(echo "$ip" | sed 's/\./\\./g')
     echo "if (\$http_x_forwarded_for ~* ${escaped_ip}) {" >> blockips.conf
     echo "    return 403;" >> blockips.conf
     echo "}" >> blockips.conf
+  done
+fi
+
+if [[ -z "$RATE_LIMITED_IPS" || "$RATE_LIMITED_IPS" == "null" ]]; then
+  echo "No RATE_LIMITED_IPS set in cloud.gov for app '${app}', skipping ratelimitedips.conf generation"
+  echo "# No rate-limited IPs configured" > ratelimitedips.conf
+else
+  echo "# Auto-generated list of rate-limited IPs" > ratelimitedips.conf
+  IFS=',' read -ra IPS <<< "$RATE_LIMITED_IPS"
+  for ip in "${IPS[@]}"; do
+    ip=$(echo "$ip" | xargs)
+    [[ -z "$ip" ]] && continue
+    echo "$ip 1;" >> ratelimitedips.conf
+  done
+fi
+
+if [[ -z "$RATE_LIMITED_ROUTES" || "$RATE_LIMITED_ROUTES" == "null" ]]; then
+  echo "No RATE_LIMITED_ROUTES set in cloud.gov for app '${app}', skipping ratelimitedroutes.conf generation"
+  echo "# No rate-limited routes configured" > ratelimitedroutes.conf
+else
+  echo "# Auto-generated list of rate-limited routes" > ratelimitedroutes.conf
+  IFS=',' read -ra ROUTES <<< "$RATE_LIMITED_ROUTES"
+  for route in "${ROUTES[@]}"; do
+    route=$(echo "$route" | xargs)
+    [[ -z "$route" ]] && continue
+    echo "~^1:${route} \$client_ip;" >> ratelimitedroutes.conf
   done
 fi

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,6 +19,24 @@ http {
   gzip_proxied any;
   gzip_types text/plain text/css text/js text/xml text/javascript application/javascript application/x-javascript application/json application/xml application/xml+rss;
 
+  map $http_x_forwarded_for $client_ip {
+    ~^(?<first_forwarded_ip>[^,\s]+) $first_forwarded_ip;
+    default $remote_addr;
+  }
+
+  geo $client_ip $rate_limited_client {
+    default 0;
+    include ratelimitedips.conf;
+  }
+
+  map "$rate_limited_client:$uri" $limited_route_key {
+    default "";
+    include ratelimitedroutes.conf;
+  }
+
+  limit_req_zone $limited_route_key zone=limited_routes_by_client:10m rate=30r/m;
+  limit_req_status 429;
+
   tcp_nopush on;
   keepalive_timeout 300;
   proxy_connect_timeout 300;
@@ -42,6 +60,7 @@ http {
     rewrite ^/files/bulk-downloads/(.*)$ {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/bulk-downloads/$1 redirect;
 
     location / {
+      limit_req zone=limited_routes_by_client burst=10 nodelay;
       resolver {{nameservers}} ipv6=off valid=1s;
       set $backend "{{env "CMS_PROXY"}}";
       proxy_pass $backend;

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,9 +38,9 @@ http {
   limit_req_status 429;
 
   tcp_nopush on;
-  keepalive_timeout 300;
-  proxy_connect_timeout 300;
-  proxy_read_timeout 300;
+  keepalive_timeout 90;
+  proxy_connect_timeout 90;
+  proxy_read_timeout 90;
   # Ensure that redirects don't include the internal container PORT - {{port}}
   port_in_redirect off;
   server_tokens off;


### PR DESCRIPTION
## Summary

Configure Nginx rate limiting for selected client IPs and selected route paths.

This also updates generated config handling so block and rate-limit include files are ignored by git.

### Required reviewers

1 engineer

## Impacted areas of the application

General components of the application that this PR will affect:

- Proxy Nginx conf
- `generate_blockips.sh` config generation

## How to test

1. Configure the dev proxy credential service with test values:

   ```text
   RATE_LIMITED_IPS=<your public IP>
   RATE_LIMITED_ROUTES=<comma-separated route prefixes to protect>
   ```

2. Generate the include files:

   ```sh
   ./generate_blockips.sh proxy dev fec-beta-fec
   ```

3. Confirm generated files exist:
   - ratelimitedips.conf
   - ratelimitedroutes.conf

6. Deploy to dev:

   ```sh
   cf push --strategy rolling proxy -f manifest_dev.yml
   cf add-network-policy proxy cms
   ```

7. Send repeated requests from the configured test IP and confirm the proxy eventually returns `429`.

8. Confirm requests from an unconfigured IP or to an unconfigured route do not return `429`.

9. Confirm OpenSearch shows `429` responses for matching dev proxy requests:

   ```text
   @cf.space:"dev" and @cf.app:"proxy" and rtr.status:"429"
   ```