### PR TITLE
[HOTFIX - merge with gitflow] Fix S3 proxy paths effected by regex captures

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -54,7 +54,7 @@ http {
     include redirects-e-regs.conf;
 
     # Redirect for bulk-downloads bucket (needed this redirect here in order to access environment variable)
-    rewrite ^/files/bulk-downloads/(.*)$ {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/bulk-downloads/$1 redirect;
+    rewrite ^/files/bulk-downloads/(?<bulk_download_path>.*)$ {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/bulk-downloads/$bulk_download_path redirect;
 
     location / {
       resolver {{nameservers}} ipv6=off valid=1s;
@@ -65,27 +65,27 @@ http {
       proxy_set_header X-Script-Name "/";
     }
 
-    location ~ /resources/(.*) {
+    location ~ ^/resources/(?<resource_path>.*) {
       resolver 8.8.8.8;
       proxy_pass_request_headers off;
-      proxy_pass {{env "S3_BUCKET_URL"}}/$1;
+      proxy_pass {{env "S3_BUCKET_URL"}}/$resource_path;
     }
 
-    location ~ /files/legal/rulemakings/(.*) {
+    location ~ ^/files/legal/rulemakings/(?<rulemaking_file_path>.*) {
       resolver 8.8.8.8;
       keepalive_timeout 180;
       proxy_pass_request_headers off;
-      proxy_pass {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/legal/rulemakings/$1;
+      proxy_pass {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/legal/rulemakings/$rulemaking_file_path;
       add_header X-Frame-Options "SAMEORIGIN" always;
       add_header X-Content-Type-Options "nosniff" always;
       add_header Cache-Control "public, max-age=300" always;
     }
 
-    location ~ /files/(.*) {
+    location ~ ^/files/(?<file_path>.*) {
       resolver 8.8.8.8;
       keepalive_timeout 180;
       proxy_pass_request_headers off;
-      proxy_pass {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/$1;
+      proxy_pass {{env "S3_LEGAL_AND_DOWNLOADS_URL"}}/$file_path;
     }
   }
 


### PR DESCRIPTION
Fix s3 paths. Don't use $1, now we use named captures so the S3 key does not get overwritten when requested.